### PR TITLE
Adding the option to shift ahead the target pose used to extract the velocity command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .svn
 .kdev4
 *.kdev4
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   nav_core
   nav_msgs
+  mbf_costmap_core
+  mbf_msgs
   roscpp
   std_msgs
   pluginlib
@@ -55,7 +57,7 @@ set(EXTERNAL_LIBS ${SUITESPARSE_LIBRARIES} ${G2O_LIBRARIES})
 ## C++11 support
 ## Unfortunately, the 3d-party dependency libg2o requires c++11 starting from ROS Jade.
 ## Even if the ROS Jade specifications do not want c++11-only packages,
-## we cannot compile without c++11 enabled. Another option would be to downgrade  
+## we cannot compile without c++11 enabled. Another option would be to downgrade
 ## libg2o third-party package.
 ## By now, if you do not want c++11, please refer to the ros indigo version.
 IF(NOT MSVC)
@@ -67,7 +69,7 @@ if(COMPILER_SUPPORTS_CXX11)
 elseif(COMPILER_SUPPORTS_CXX0X)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 else()
-  message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support which is required 
+  message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support which is required
   by linked third party packages starting from ROS Jade. Ignore this message for ROS Indigo.")
 endif()
 endif()

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -193,9 +193,10 @@ public:
    * @param[out] vx translational velocity [m/s]
    * @param[out] vy strafing velocity which can be nonzero for holonomic robots [m/s]
    * @param[out] omega rotational velocity [rad/s]
+   * @param[in] look_ahead_poses index of the final pose used to compute the velocity command.
    * @return \c true if command is valid, \c false otherwise
    */
-  virtual bool getVelocityCommand(double& vx, double& vy, double& omega) const;
+  virtual bool getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const;
 
   /**
    * @brief Access current best trajectory candidate (that relates to the "best" homotopy class).

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -281,15 +281,6 @@ public:
    */
   void exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel);
 
-
-  /**
-   * @brief Check all available trajectories (TEBs) for detours and delete found ones.
-   * @see TimedElasticBand::detectDetoursBackwards
-   * @param threshold Threshold paramter for allowed orientation changes (below 0 -> greater than 90 deg)
-   */
-  void deleteTebDetours(double threshold=0.0);
-
-
   /**
    * @brief Add a new Teb to the internal trajectory container, if this teb constitutes a new equivalence class. Initialize it using a generic 2D reference path
    *
@@ -487,7 +478,7 @@ public:
   /**
    * @brief Internal helper function that adds a new equivalence class to the list of known classes only if it is unique.
    * @param eq_class equivalence class that should be tested
-   * @param lock if \c true, exclude the H-signature from deletion, e.g. in deleteTebDetours().
+   * @param lock if \c true, exclude the H-signature from deletion.
    * @return \c true if the h-signature was added and no duplicate was found, \c false otherwise
    */
   bool addEquivalenceClassIfNew(const EquivalenceClassPtr& eq_class, bool lock=false);
@@ -519,7 +510,7 @@ protected:
    * First all old h-signatures are deleted, since they could be invalid for this planning step (obstacle position may changed).
    * Afterwards the h-signatures are calculated for each existing TEB/trajectory and is inserted to the list of known h-signatures.
    * Doing this is important to prefer already optimized trajectories in contrast to initialize newly explored coarse paths.
-   * @param delete_detours if this param is \c true, all existing TEBs are cleared from detour-candidates by utilizing deleteTebDetours().
+   * @param delete_detours if this param is \c true, all existing TEBs are cleared from detour-candidates calling deletePlansGoingBackwards().
    */
   void renewAndAnalyzeOldTebs(bool delete_detours);
 

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -435,6 +435,23 @@ public:
         return true; // Found! Homotopy class already exists, therefore nothing added
       return false;
   }
+  /**
+   * @brief Checks if the orientation of the computed trajectories differs from that of the best plan of more than the
+   *  specified threshold and eventually deletes them.
+   * @param orient_threshold: Threshold paramter for allowed orientation changes in radians
+   * @param len_orientation_vector: length of the vector used to compute the start orientation
+   */
+  void deletePlansDetouringBackwards(const double orient_threshold, const double len_orientation_vector);
+  /**
+   * @brief Given a plan, computes its start orientation using a vector of length >= len_orientation_vector
+   *        starting from the initial pose.
+   * @param plan: Teb to be analyzed
+   * @param len_orientation_vector: min length of the vector used to compute the start orientation
+   * @param orientation: computed start orientation
+   * @return: Could the vector for the orientation check be computed? (False if the plan has no pose with a distance
+   *          > len_orientation_vector from the start poseq)
+   */
+  bool computeStartOrientation(const TebOptimalPlannerPtr plan, const double len_orientation_vector, double& orientation);
 
 
   /**

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -210,9 +210,10 @@ public:
    * @param[out] vx translational velocity [m/s]
    * @param[out] vy strafing velocity which can be nonzero for holonomic robots[m/s] 
    * @param[out] omega rotational velocity [rad/s]
+   * @param[in] look_ahead_poses index of the final pose used to compute the velocity command.
    * @return \c true if command is valid, \c false otherwise
    */
-  virtual bool getVelocityCommand(double& vx, double& vy, double& omega) const;
+  virtual bool getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const;
   
   
   /**

--- a/include/teb_local_planner/planner_interface.h
+++ b/include/teb_local_planner/planner_interface.h
@@ -129,9 +129,10 @@ public:
    * @param[out] vx translational velocity [m/s]
    * @param[out] vy strafing velocity which can be nonzero for holonomic robots [m/s] 
    * @param[out] omega rotational velocity [rad/s]
+   * @param[in] look_ahead_poses index of the final pose used to compute the velocity command.
    * @return \c true if command is valid, \c false otherwise
    */
-  virtual bool getVelocityCommand(double& vx, double& vy, double& omega) const = 0;
+  virtual bool getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const = 0;
   
   //@}
   

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -188,6 +188,9 @@ public:
     
     bool visualize_hc_graph; //!< Visualize the graph that is created for exploring new homotopy classes.
     double visualize_with_time_as_z_axis_scale; //!< If this value is bigger than 0, the trajectory and obstacles are visualized in 3d using the time as the z-axis scaled by this value. Most useful for dynamic obstacles.
+    bool delete_detours_backwards; //!< If enabled, the planner will discard the plans detouring backwards with respect to the best plan
+    double detours_orientation_tolerance; //!< A plan is considered a detour if its start orientation differs more than this from the best plan
+    double length_start_orientation_vector; //!< Length of the vector used to compute the start orientation of a plan
   } hcp;
   
   //! Recovery/backup related parameters
@@ -328,6 +331,9 @@ public:
     
     hcp.visualize_hc_graph = false;
     hcp.visualize_with_time_as_z_axis_scale = 0.0;
+    hcp.delete_detours_backwards = true;
+    hcp.detours_orientation_tolerance = M_PI / 2.0;
+    hcp.length_start_orientation_vector = 0.4;
     
     // Recovery
     

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -83,6 +83,7 @@ public:
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
     double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]
+    int control_look_ahead_poses; //! Index of the pose used to extract the velocity command
   } trajectory; //!< Trajectory related parameters
     
   //! Robot related parameters
@@ -242,7 +243,8 @@ public:
     trajectory.feasibility_check_no_poses = 5;
     trajectory.publish_feedback = false;
     trajectory.min_resolution_collision_check_angular = M_PI;
-    
+    trajectory.control_look_ahead_poses = 1;
+
     // Robot
          
     robot.max_vel_x = 0.4;

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -43,6 +43,7 @@
 
 // base local planner base class and utilities
 #include <nav_core/base_local_planner.h>
+#include <mbf_costmap_core/costmap_controller.h>
 #include <base_local_planner/goal_functions.h>
 #include <base_local_planner/odometry_helper_ros.h>
 #include <base_local_planner/costmap_model.h>
@@ -86,10 +87,11 @@ namespace teb_local_planner
 
 /**
   * @class TebLocalPlannerROS
-  * @brief Implements the actual abstract navigation stack routines of the teb_local_planner plugin
+  * @brief Implements both nav_core::BaseLocalPlanner and mbf_costmap_core::CostmapController abstract
+  * interfaces, so the teb_local_planner plugin can be used both in move_base and move_base_flex (MBF).
   * @todo Escape behavior, more efficient obstacle handling
   */
-class TebLocalPlannerROS : public nav_core::BaseLocalPlanner
+class TebLocalPlannerROS : public nav_core::BaseLocalPlanner, public mbf_costmap_core::CostmapController
 {
 
 public:
@@ -126,22 +128,63 @@ public:
   bool computeVelocityCommands(geometry_msgs::Twist& cmd_vel);
 
   /**
+    * @brief Given the current position, orientation, and velocity of the robot, compute velocity commands to send to the base.
+    * @remark Extended version for MBF API
+    * @param pose the current pose of the robot.
+    * @param velocity the current velocity of the robot.
+    * @param cmd_vel Will be filled with the velocity command to be passed to the robot base.
+    * @param message Optional more detailed outcome as a string
+    * @return Result code as described on ExePath action result:
+    *         SUCCESS         = 0
+    *         1..9 are reserved as plugin specific non-error results
+    *         FAILURE         = 100   Unspecified failure, only used for old, non-mfb_core based plugins
+    *         CANCELED        = 101
+    *         NO_VALID_CMD    = 102
+    *         PAT_EXCEEDED    = 103
+    *         COLLISION       = 104
+    *         OSCILLATION     = 105
+    *         ROBOT_STUCK     = 106
+    *         MISSED_GOAL     = 107
+    *         MISSED_PATH     = 108
+    *         BLOCKED_PATH    = 109
+    *         INVALID_PATH    = 110
+    *         TF_ERROR        = 111
+    *         NOT_INITIALIZED = 112
+    *         INVALID_PLUGIN  = 113
+    *         INTERNAL_ERROR  = 114
+    *         121..149 are reserved as plugin specific errors
+    */
+  uint32_t computeVelocityCommands(const geometry_msgs::PoseStamped& pose, const geometry_msgs::TwistStamped& velocity,
+                                   geometry_msgs::TwistStamped &cmd_vel, std::string &message);
+
+  /**
     * @brief  Check if the goal pose has been achieved
-    * 
-    * The actual check is performed in computeVelocityCommands(). 
+    *
+    * The actual check is performed in computeVelocityCommands().
     * Only the status flag is checked here.
     * @return True if achieved, false otherwise
     */
   bool isGoalReached();
-  
-  
-    
+
+  /**
+    * @brief Dummy version to satisfy MBF API
+    */
+  bool isGoalReached(double xy_tolerance, double yaw_tolerance) { return isGoalReached(); };
+
+  /**
+    * @brief Requests the planner to cancel, e.g. if it takes too much time
+    * @remark New on MBF API
+    * @return True if a cancel has been successfully requested, false if not implemented.
+    */
+  bool cancel() { return false; };
+
+
   /** @name Public utility functions/methods */
   //@{
-  
+
     /**
     * @brief  Transform a tf::Pose type into a Eigen::Vector2d containing the translational and angular velocities.
-    * 
+    *
     * Translational velocities (x- and y-coordinates) are combined into a single translational velocity (first component).
     * @param tf_vel tf::Pose message containing a 1D or 2D translational velocity (x,y) and an angular velocity (yaw-angle)
     * @return Translational and angular velocity combined into an Eigen::Vector2d
@@ -154,32 +197,32 @@ public:
    * @return Robot footprint model used for optimization
    */
   static RobotFootprintModelPtr getRobotFootprintFromParamServer(const ros::NodeHandle& nh);
-  
-    /** 
+
+    /**
    * @brief Set the footprint from the given XmlRpcValue.
    * @remarks This method is copied from costmap_2d/footprint.h, since it is not declared public in all ros distros
    * @remarks It is modified in order to return a container of Eigen::Vector2d instead of geometry_msgs::Point
    * @param footprint_xmlrpc should be an array of arrays, where the top-level array should have 3 or more elements, and the
    * sub-arrays should all have exactly 2 elements (x and y coordinates).
-   * @param full_param_name this is the full name of the rosparam from which the footprint_xmlrpc value came. 
-   * It is used only for reporting errors. 
+   * @param full_param_name this is the full name of the rosparam from which the footprint_xmlrpc value came.
+   * It is used only for reporting errors.
    * @return container of vertices describing the polygon
    */
   static Point2dContainer makeFootprintFromXMLRPC(XmlRpc::XmlRpcValue& footprint_xmlrpc, const std::string& full_param_name);
-  
-  /** 
+
+  /**
    * @brief Get a number from the given XmlRpcValue.
    * @remarks This method is copied from costmap_2d/footprint.h, since it is not declared public in all ros distros
    * @remarks It is modified in order to return a container of Eigen::Vector2d instead of geometry_msgs::Point
    * @param value double value type
-   * @param full_param_name this is the full name of the rosparam from which the footprint_xmlrpc value came. 
-   * It is used only for reporting errors. 
+   * @param full_param_name this is the full name of the rosparam from which the footprint_xmlrpc value came.
+   * It is used only for reporting errors.
    * @returns double value
    */
   static double getNumberFromXMLRPC(XmlRpc::XmlRpcValue& value, const std::string& full_param_name);
-  
+
   //@}
-  
+
 protected:
 
   /**
@@ -191,7 +234,7 @@ protected:
     * @todo Include properties for dynamic obstacles (e.g. using constant velocity model)
     */
   void updateObstacleContainerWithCostmap();
-  
+
   /**
    * @brief Update internal obstacle vector based on polygons provided by a costmap_converter plugin
    * @remarks Requires a loaded costmap_converter plugin.
@@ -199,7 +242,7 @@ protected:
    * @sa updateObstacleContainerWithCostmap
    */
   void updateObstacleContainerWithCostmapConverter();
-  
+
   /**
    * @brief Update internal obstacle vector based on custom messages received via subscriber
    * @remarks All previous obstacles are NOT cleared. Call this method after other update methods.
@@ -215,24 +258,24 @@ protected:
    * @param min_separation minimum separation between two consecutive via-points
    */
   void updateViaPointsContainer(const std::vector<geometry_msgs::PoseStamped>& transformed_plan, double min_separation);
-  
-  
+
+
   /**
     * @brief Callback for the dynamic_reconfigure node.
-    * 
+    *
     * This callback allows to modify parameters dynamically at runtime without restarting the node
     * @param config Reference to the dynamic reconfigure config
     * @param level Dynamic reconfigure level
     */
   void reconfigureCB(TebLocalPlannerReconfigureConfig& config, uint32_t level);
-  
-  
+
+
    /**
-    * @brief Callback for custom obstacles that are not obtained from the costmap 
+    * @brief Callback for custom obstacles that are not obtained from the costmap
     * @param obst_msg pointer to the message containing a list of polygon shaped obstacles
     */
   void customObstacleCB(const costmap_converter::ObstacleArrayMsg::ConstPtr& obst_msg);
-  
+
    /**
     * @brief Callback for custom via-points
     * @param via_points_msg pointer to the message containing a list of via-points
@@ -241,7 +284,7 @@ protected:
 
    /**
     * @brief Prune global plan such that already passed poses are cut off
-    * 
+    *
     * The pose of the robot is transformed into the frame of the global plan by taking the most recent tf transform.
     * If no valid transformation can be found, the method returns \c false.
     * The global plan is pruned until the distance to the robot is at least \c dist_behind_robot.
@@ -254,14 +297,14 @@ protected:
     * @param dist_behind_robot Distance behind the robot that should be kept [meters]
     * @return \c true if the plan is pruned, \c false in case of a transform exception or if no pose cannot be found inside the threshold
     */
-  bool pruneGlobalPlan(const tf::TransformListener& tf, const tf::Stamped<tf::Pose>& global_pose, 
+  bool pruneGlobalPlan(const tf::TransformListener& tf, const tf::Stamped<tf::Pose>& global_pose,
                        std::vector<geometry_msgs::PoseStamped>& global_plan, double dist_behind_robot=1);
-  
+
   /**
     * @brief  Transforms the global plan of the robot from the planner frame to the local frame (modified).
-    * 
-    * The method replaces transformGlobalPlan as defined in base_local_planner/goal_functions.h 
-    * such that the index of the current goal pose is returned as well as 
+    *
+    * The method replaces transformGlobalPlan as defined in base_local_planner/goal_functions.h
+    * such that the index of the current goal pose is returned as well as
     * the transformation between the global plan and the planning frame.
     * @param tf A reference to a transform listener
     * @param global_plan The plan to be transformed
@@ -278,13 +321,13 @@ protected:
                            const tf::Stamped<tf::Pose>& global_pose,  const costmap_2d::Costmap2D& costmap,
                            const std::string& global_frame, double max_plan_length, std::vector<geometry_msgs::PoseStamped>& transformed_plan,
                            int* current_goal_idx = NULL, tf::StampedTransform* tf_plan_to_global = NULL) const;
-    
+
   /**
     * @brief Estimate the orientation of a pose from the global_plan that is treated as a local goal for the local planner.
-    * 
+    *
     * If the current (local) goal point is not the final one (global)
-    * substitute the goal orientation by the angle of the direction vector between 
-    * the local goal and the subsequent pose of the global plan. 
+    * substitute the goal orientation by the angle of the direction vector between
+    * the local goal and the subsequent pose of the global plan.
     * This is often helpful, if the global planner does not consider orientations. \n
     * A moving average filter is utilized to smooth the orientation.
     * @param global_plan The global plan
@@ -296,11 +339,11 @@ protected:
     */
   double estimateLocalGoalOrientation(const std::vector<geometry_msgs::PoseStamped>& global_plan, const tf::Stamped<tf::Pose>& local_goal,
                                       int current_goal_idx, const tf::StampedTransform& tf_plan_to_global, int moving_average_length=3) const;
-        
-        
+
+
   /**
    * @brief Saturate the translational and angular velocity to given limits.
-   * 
+   *
    * The limit of the translational velocity for backwards driving can be changed independently.
    * Do not choose max_vel_x_backwards <= 0. If no backward driving is desired, change the optimization weight for
    * penalizing backwards driving instead.
@@ -315,10 +358,10 @@ protected:
   void saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y,
                         double max_vel_theta, double max_vel_x_backwards) const;
 
-  
+
   /**
    * @brief Convert translational and rotational velocities to a steering angle of a carlike robot
-   * 
+   *
    * The conversion is based on the following equations:
    * - The turning radius is defined by \f$ R = v/omega \f$
    * - For a car like robot withe a distance L between both axles, the relation is: \f$ tan(\phi) = L/R \f$
@@ -331,10 +374,10 @@ protected:
    * @return Resulting steering angle in [rad] inbetween [-pi/2, pi/2]
    */
   double convertTransRotVelToSteeringAngle(double v, double omega, double wheelbase, double min_turning_radius = 0) const;
-  
+
   /**
    * @brief Validate current parameter values of the footprint for optimization, obstacle distance and the costmap footprint
-   * 
+   *
    * This method prints warnings if validation fails.
    * @remarks Currently, we only validate the inscribed radius of the footprints
    * @param opt_inscribed_radius Inscribed radius of the RobotFootprintModel for optimization
@@ -342,12 +385,12 @@ protected:
    * @param min_obst_dist desired distance to obstacles
    */
   void validateFootprints(double opt_inscribed_radius, double costmap_inscribed_radius, double min_obst_dist);
-  
-  
+
+
   void configureBackupModes(std::vector<geometry_msgs::PoseStamped>& transformed_plan,  int& goal_idx);
 
 
-  
+
 private:
   // Definition of member variables
 
@@ -355,22 +398,22 @@ private:
   costmap_2d::Costmap2DROS* costmap_ros_; //!< Pointer to the costmap ros wrapper, received from the navigation stack
   costmap_2d::Costmap2D* costmap_; //!< Pointer to the 2d costmap (obtained from the costmap ros wrapper)
   tf::TransformListener* tf_; //!< pointer to Transform Listener
-    
+
   // internal objects (memory management owned)
   PlannerInterfacePtr planner_; //!< Instance of the underlying optimal planner class
   ObstContainer obstacles_; //!< Obstacle vector that should be considered during local trajectory optimization
   ViaPointContainer via_points_; //!< Container of via-points that should be considered during local trajectory optimization
   TebVisualizationPtr visualization_; //!< Instance of the visualization class (local/global plan, obstacles, ...)
-  boost::shared_ptr<base_local_planner::CostmapModel> costmap_model_;  
+  boost::shared_ptr<base_local_planner::CostmapModel> costmap_model_;
   TebConfig cfg_; //!< Config class that stores and manages all related parameters
   FailureDetector failure_detector_; //!< Detect if the robot got stucked
-  
+
   std::vector<geometry_msgs::PoseStamped> global_plan_; //!< Store the current global plan
-  
+
   base_local_planner::OdometryHelperRos odom_helper_; //!< Provides an interface to receive the current velocity from the robot
-  
+
   pluginlib::ClassLoader<costmap_converter::BaseCostmapToPolygons> costmap_converter_loader_; //!< Load costmap converter plugins at runtime
-  boost::shared_ptr<costmap_converter::BaseCostmapToPolygons> costmap_converter_; //!< Store the current costmap_converter  
+  boost::shared_ptr<costmap_converter::BaseCostmapToPolygons> costmap_converter_; //!< Store the current costmap_converter
 
   boost::shared_ptr< dynamic_reconfigure::Server<TebLocalPlannerReconfigureConfig> > dynamic_recfg_; //!< Dynamic reconfigure server to allow config modifications at runtime
   ros::Subscriber custom_obst_sub_; //!< Subscriber for custom obstacles received via a ObstacleMsg.
@@ -390,21 +433,21 @@ private:
   ros::Time time_last_oscillation_; //!< Store at which time stamp the last oscillation was detected
   RotType last_preferred_rotdir_; //!< Store recent preferred turning direction
   geometry_msgs::Twist last_cmd_; //!< Store the last control command generated in computeVelocityCommands()
-  
-  std::vector<geometry_msgs::Point> footprint_spec_; //!< Store the footprint of the robot 
+
+  std::vector<geometry_msgs::Point> footprint_spec_; //!< Store the footprint of the robot
   double robot_inscribed_radius_; //!< The radius of the inscribed circle of the robot (collision possible)
   double robot_circumscribed_radius; //!< The radius of the circumscribed circle of the robot
-  
+
   std::string global_frame_; //!< The frame in which the controller will run
   std::string robot_base_frame_; //!< Used as the base frame id of the robot
-    
+
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
-  
+
 }; // end namespace teb_local_planner
 
 #endif // TEB_LOCAL_PLANNER_ROS_H_

--- a/include/teb_local_planner/timed_elastic_band.h
+++ b/include/teb_local_planner/timed_elastic_band.h
@@ -625,22 +625,6 @@ public:
   double getAccumulatedDistance() const;
   
   /**
-   * @brief Detect whether the trajectory contains detours.
-   * 
-   * Two different cases forces the method to return \c true : \n
-   * 	1. The trajectory contain parts that increase the distance to the goal. \n
-   * 	   This is checked by comparing the orientations theta_i with the goal heading. \n
-   * 	   If the scalar product is below the \c threshold param, the method returns \c true.
-   * 	2. The trajectory consist of backwards motions at the beginning of the trajectory,
-   * 	   e.g. the second pose is behind the start pose w.r.t. to the same goal heading.
-   * 
-   * Detours are not critical, but can be takein into account if multiple trajectory candidates are avaiable.
-   * @param threshold Threshold paramter for allowed orientation changes (below 0 -> greater than 90 deg)
-   * @return \c true if one of both cases mentioned above are satisfied, false otherwise
-   */
-  bool detectDetoursBackwards(double threshold=0) const;
-  
-  /**
    * @brief Check if all trajectory points are contained in a specific region
    * 
    * The specific region is a circle around the current robot position (Pose(0)) with given radius \c radius.

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
     to the base_local_planner of the 2D navigation stack.
     The underlying method called Timed Elastic Band locally optimizes
     the robot's trajectory with respect to trajectory execution time,
-    separation from obstacles and compliance with kinodynamic constraints at runtime.	
+    separation from obstacles and compliance with kinodynamic constraints at runtime.
   </description>
 
 
@@ -23,10 +23,10 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>message_generation</build_depend>
-  
+
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
-  
+
   <depend>base_local_planner</depend>
   <depend>costmap_2d</depend>
   <depend>costmap_converter</depend>
@@ -37,6 +37,8 @@
   <depend>libg2o</depend>
   <depend>nav_core</depend>
   <depend>nav_msgs</depend>
+  <depend>mbf_costmap_core</depend>
+  <depend>mbf_msgs</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
@@ -46,5 +48,6 @@
 
   <export>
     <nav_core plugin="${prefix}/teb_local_planner_plugin.xml"/>
+    <mbf_costmap_core plugin="${prefix}/teb_local_planner_plugin.xml"/>
   </export>
 </package>

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -125,7 +125,7 @@ bool HomotopyClassPlanner::plan(const PoseSE2& start, const PoseSE2& goal, const
   return true;
 }
 
-bool HomotopyClassPlanner::getVelocityCommand(double& vx, double& vy, double& omega) const
+bool HomotopyClassPlanner::getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const
 {
   TebOptimalPlannerConstPtr best_teb = bestTeb();
   if (!best_teb)
@@ -136,7 +136,7 @@ bool HomotopyClassPlanner::getVelocityCommand(double& vx, double& vy, double& om
     return false;
   }
 
-  return best_teb->getVelocityCommand(vx, vy, omega);
+  return best_teb->getVelocityCommand(vx, vy, omega, look_ahead_poses);
 }
 
 

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -733,6 +733,12 @@ void HomotopyClassPlanner::deletePlansDetouringBackwards(const double orient_thr
       it_teb = removeTeb(*it_teb);  // Plan detouring backwards
       continue;
     }
+    if(!it_teb->get()->isOptimized())
+    {
+      ROS_DEBUG("Removing a teb because it's not optimized");
+      it_teb = removeTeb(*it_teb);  // Deletes tebs that cannot be optimized (last optim call failed)
+      continue;
+    }
     ++it_teb;
   }
 }

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -118,8 +118,6 @@ bool HomotopyClassPlanner::plan(const PoseSE2& start, const PoseSE2& goal, const
   updateReferenceTrajectoryViaPoints(cfg_->hcp.viapoints_all_candidates);
   // Optimize all trajectories in alternative homotopy classes
   optimizeAllTEBs(cfg_->optim.no_inner_iterations, cfg_->optim.no_outer_iterations);
-  // Delete any detours
-  deleteTebDetours(-0.1);
   // Select which candidate (based on alternative homotopy classes) should be used
   selectBestTeb();
 
@@ -232,13 +230,6 @@ void HomotopyClassPlanner::renewAndAnalyzeOldTebs(bool delete_detours)
   TebOptPlannerContainer::iterator it_teb = has_best_teb ? std::next(tebs_.begin(), 1) : tebs_.begin();
   while(it_teb != tebs_.end())
   {
-    // delete Detours if there is at least one other TEB candidate left in the container
-    if (delete_detours && tebs_.size()>1 && it_teb->get()->teb().detectDetoursBackwards(-0.1))
-    {
-      it_teb = tebs_.erase(it_teb); // delete candidate and set iterator to the next valid candidate
-      continue;
-    }
-
     // calculate equivalence class for the current candidate
     EquivalenceClassPtr equivalence_class = calculateEquivalenceClass(it_teb->get()->teb().poses().begin(), it_teb->get()->teb().poses().end(), getCplxFromVertexPosePtr , obstacles_,
                                                                       it_teb->get()->teb().timediffs().begin(), it_teb->get()->teb().timediffs().end());
@@ -256,6 +247,8 @@ void HomotopyClassPlanner::renewAndAnalyzeOldTebs(bool delete_detours)
 
     ++it_teb;
   }
+  if(delete_detours)
+    deletePlansDetouringBackwards(cfg_->hcp.detours_orientation_tolerance, cfg_->hcp.length_start_orientation_vector);
 
   // Find multiple candidates and delete the one with higher cost
   // TODO: this code needs to be adpated. Erasing tebs from the teb container_ could make iteratores stored in the candidate list invalid!
@@ -339,7 +332,7 @@ void HomotopyClassPlanner::updateReferenceTrajectoryViaPoints(bool all_trajector
 void HomotopyClassPlanner::exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel)
 {
   // first process old trajectories
-  renewAndAnalyzeOldTebs(false);
+  renewAndAnalyzeOldTebs(cfg_->hcp.delete_detours_backwards);
 
   // inject initial plan if available and not yet captured
   if (initial_plan_)
@@ -388,7 +381,8 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<ge
     return TebOptimalPlannerPtr();
   TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_));
 
-  candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, true, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
+  candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x,
+    cfg_->trajectory.global_plan_overwrite_orientation, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
 
   if (start_velocity)
     candidate->setVelocityStart(*start_velocity);
@@ -453,53 +447,6 @@ void HomotopyClassPlanner::optimizeAllTEBs(int iter_innerloop, int iter_outerloo
     {
       it_teb->get()->optimizeTEB(iter_innerloop,iter_outerloop, true, cfg_->hcp.selection_obst_cost_scale,
                                  cfg_->hcp.selection_viapoint_cost_scale, cfg_->hcp.selection_alternative_time_cost); // compute cost as well inside optimizeTEB (last argument = true)
-    }
-  }
-}
-
-void HomotopyClassPlanner::deleteTebDetours(double threshold)
-{
-  TebOptPlannerContainer::iterator it_teb = tebs_.begin();
-  EquivalenceClassContainer::iterator it_eqclasses = equivalence_classes_.begin();
-
-  if (tebs_.size() != equivalence_classes_.size())
-  {
-    ROS_ERROR("HomotopyClassPlanner::deleteTebDetours(): number of equivalence classes (%lu) and trajectories (%lu) does not match.", equivalence_classes_.size(), tebs_.size());
-    return;
-  }
-
-  bool modified;
-
-  while(it_teb != tebs_.end())
-  {
-    modified = false;
-
-    if (!it_eqclasses->second) // check if equivalence class is locked
-    {
-      // delete Detours if other TEBs will remain!
-      if (tebs_.size()>1 && (it_teb->get()->teb().detectDetoursBackwards(threshold) || !it_eqclasses->first->isReasonable()))
-      {
-        it_teb = tebs_.erase(it_teb);
-        it_eqclasses = equivalence_classes_.erase(it_eqclasses);
-        modified = true;
-        continue;
-      }
-    }
-
-    // Also delete tebs that cannot be optimized (last optim call failed)
-    // here, we ignore the lock-state, since we cannot keep trajectories that are not optimizable
-    if (!it_teb->get()->isOptimized())
-    {
-      it_teb = tebs_.erase(it_teb);
-      it_eqclasses = equivalence_classes_.erase(it_eqclasses);
-      modified = true;
-      ROS_DEBUG("HomotopyClassPlanner::deleteTebDetours(): removing candidate that was not optimized successfully");
-    }
-
-    if (!modified)
-    {
-      ++it_teb;
-      ++it_eqclasses;
     }
   }
 }
@@ -748,6 +695,67 @@ void HomotopyClassPlanner::computeCurrentCost(std::vector<double>& cost, double 
   {
     it_teb->get()->computeCurrentCost(cost, obst_cost_scale, viapoint_cost_scale, alternative_time_cost);
   }
+}
+
+void HomotopyClassPlanner::deletePlansDetouringBackwards(const double orient_threshold,
+  const double len_orientation_vector)
+{
+  if (tebs_.size() < 2 || !best_teb_ || std::find(tebs_.begin(), tebs_.end(), best_teb_) == tebs_.end() ||
+    best_teb_->teb().sizePoses() < 2)
+  {
+    return;  // A moving direction wasn't chosen yet
+  }
+  double current_movement_orientation;
+  if(!computeStartOrientation(best_teb_, len_orientation_vector, current_movement_orientation))
+    return;  // The plan is shorter than len_orientation_vector
+  for(auto it_teb = tebs_.begin(); it_teb != tebs_.end();)
+  {
+    if(*it_teb == best_teb_)  // The current plan should not be considered a detour
+    {
+      ++it_teb;
+      continue;
+    }
+    if((*it_teb)->teb().sizePoses() < 2)
+    {
+      ROS_DEBUG("Discarding a plan with less than 2 poses");
+      it_teb = removeTeb(*it_teb);
+      continue;
+    }
+    double plan_orientation;
+    if(!computeStartOrientation(*it_teb, len_orientation_vector, plan_orientation))
+    {
+      ROS_DEBUG("Failed to compute the start orientation for one of the tebs, likely close to the target");
+      it_teb = removeTeb(*it_teb);
+      continue;
+    }
+    if(fabs(g2o::normalize_theta(plan_orientation - current_movement_orientation)) > orient_threshold)
+    {
+      it_teb = removeTeb(*it_teb);  // Plan detouring backwards
+      continue;
+    }
+    ++it_teb;
+  }
+}
+
+bool HomotopyClassPlanner::computeStartOrientation(const TebOptimalPlannerPtr plan, const double len_orientation_vector,
+  double& orientation)
+{
+  VertexPose start_pose = plan->teb().Pose(0);
+  bool second_pose_found = false;
+  Eigen::Vector2d start_vector;
+  for(auto& pose : plan->teb().poses())
+  {
+    start_vector = start_pose.position() - pose->position();
+    if(start_vector.norm() > len_orientation_vector)
+    {
+      second_pose_found = true;
+      break;
+    }
+  }
+  if(!second_pose_found)  // The current plan is too short to make assumptions on the start orientation
+    return false;
+  orientation = std::atan2(start_vector[1], start_vector[0]);
+  return true;
 }
 
 

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1101,7 +1101,7 @@ void TebOptimalPlanner::extractVelocity(const PoseSE2& pose1, const PoseSE2& pos
   omega = orientdiff/dt;
 }
 
-bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega) const
+bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const
 {
   if (teb_.sizePoses()<2)
   {
@@ -1111,8 +1111,10 @@ bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega
     omega = 0;
     return false;
   }
-
-  double dt = teb_.TimeDiff(0);
+  look_ahead_poses = std::max(1, std::min(look_ahead_poses, teb_.sizePoses() - 1));
+  double dt = 0.0;
+  for(int counter = 0; counter < look_ahead_poses; ++counter)
+    dt += teb_.TimeDiff(counter);
   if (dt<=0)
   {
     ROS_ERROR("TebOptimalPlanner::getVelocityCommand() - timediff<=0 is invalid!");
@@ -1123,7 +1125,7 @@ bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega
   }
 
   // Get velocity from the first two configurations
-  extractVelocity(teb_.Pose(0), teb_.Pose(1), dt, vx, vy, omega);
+  extractVelocity(teb_.Pose(0), teb_.Pose(look_ahead_poses), dt, vx, vy, omega);
   return true;
 }
 

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1215,7 +1215,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
 
   for (int i=0; i <= look_ahead_idx; ++i)
   {
-    if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) < 0 ) {
+    if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) == -1 ) {
       if (visualization_) {
         visualization_->publishRobotFootprintModel(teb_.Pose(i), *robot_model_);
       }
@@ -1233,7 +1233,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
       {
         // check one more time
         PoseSE2 center = PoseSE2::average(teb().Pose(i), teb().Pose(i+1));
-        if ( costmap_model->footprintCost(center.x(), center.y(), center.theta(), footprint_spec, inscribed_radius, circumscribed_radius) < 0 ) {
+        if ( costmap_model->footprintCost(center.x(), center.y(), center.theta(), footprint_spec, inscribed_radius, circumscribed_radius) == -1 ) {
           if (visualization_) {
             visualization_->publishRobotFootprintModel(center, *robot_model_);
           }

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1215,8 +1215,12 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
 
   for (int i=0; i <= look_ahead_idx; ++i)
   {
-    if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) < 0 )
+    if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) < 0 ) {
+      if (visualization_) {
+        visualization_->publishRobotFootprintModel(teb_.Pose(i), *robot_model_);
+      }
       return false;
+    }
 
     // check if distance between two poses is higher than the robot radius and interpolate in that case
     // (if obstacles are pushing two consecutive poses away, the center between two consecutive poses might coincide with the obstacle ;-)!
@@ -1227,24 +1231,15 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
       Eigen::Vector2d delta_dist = teb().Pose(i+1).position()-teb().Pose(i).position();
       if(fabs(delta_rot) > cfg_->trajectory.min_resolution_collision_check_angular || delta_dist.norm() > inscribed_radius)
       {
-        int n_additional_samples = std::max(std::ceil(fabs(delta_rot) / cfg_->trajectory.min_resolution_collision_check_angular), 
-                                            std::ceil(delta_dist.norm() / inscribed_radius)) - 1;
-        PoseSE2 intermediate_pose = teb().Pose(i);
-        for(int step = 0; step < n_additional_samples; ++step)
-        {
-          intermediate_pose.position() = intermediate_pose.position() + delta_dist / (n_additional_samples + 1.0);
-          intermediate_pose.theta() = g2o::normalize_theta(intermediate_pose.theta() + 
-                                                           delta_rot / (n_additional_samples + 1.0));
-          if ( costmap_model->footprintCost(intermediate_pose.x(), intermediate_pose.y(), intermediate_pose.theta(),
-            footprint_spec, inscribed_radius, circumscribed_radius) == -1 )
-          {
-            if (visualization_) 
-            {
-              visualization_->publishRobotFootprintModel(intermediate_pose, *robot_model_);
-            }
-            return false;
+        // check one more time
+        PoseSE2 center = PoseSE2::average(teb().Pose(i), teb().Pose(i+1));
+        if ( costmap_model->footprintCost(center.x(), center.y(), center.theta(), footprint_spec, inscribed_radius, circumscribed_radius) < 0 ) {
+          if (visualization_) {
+            visualization_->publishRobotFootprintModel(center, *robot_model_);
           }
+          return false;
         }
+
       }
 
     }

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -48,11 +48,11 @@ namespace teb_local_planner
 
 TebOptimalPlanner::TebOptimalPlanner() : cfg_(NULL), obstacles_(NULL), via_points_(NULL), cost_(HUGE_VAL), prefer_rotdir_(RotType::none),
                                          robot_model_(new PointRobotFootprint()), initialized_(false), optimized_(false)
-{    
+{
 }
-  
+
 TebOptimalPlanner::TebOptimalPlanner(const TebConfig& cfg, ObstContainer* obstacles, RobotFootprintModelPtr robot_model, TebVisualizationPtr visual, const ViaPointContainer* via_points)
-{    
+{
   initialize(cfg, obstacles, robot_model, visual, via_points);
 }
 
@@ -60,17 +60,17 @@ TebOptimalPlanner::~TebOptimalPlanner()
 {
   clearGraph();
   // free dynamically allocated memory
-  //if (optimizer_) 
+  //if (optimizer_)
   //  g2o::Factory::destroy();
   //g2o::OptimizationAlgorithmFactory::destroy();
   //g2o::HyperGraphActionLibrary::destroy();
 }
 
 void TebOptimalPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacles, RobotFootprintModelPtr robot_model, TebVisualizationPtr visual, const ViaPointContainer* via_points)
-{    
+{
   // init optimizer (set solver and block ordering settings)
   optimizer_ = initOptimizer();
-  
+
   cfg_ = &cfg;
   obstacles_ = obstacles;
   robot_model_ = robot_model;
@@ -78,7 +78,7 @@ void TebOptimalPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacle
   cost_ = HUGE_VAL;
   prefer_rotdir_ = RotType::none;
   setVisualization(visual);
-  
+
   vel_start_.first = true;
   vel_start_.second.linear.x = 0;
   vel_start_.second.linear.y = 0;
@@ -101,15 +101,15 @@ void TebOptimalPlanner::visualize()
 {
   if (!visualization_)
     return;
- 
+
   visualization_->publishLocalPlanAndPoses(teb_);
-  
+
   if (teb_.sizePoses() > 0)
     visualization_->publishRobotFootprintModel(teb_.Pose(0), *robot_model_);
-  
+
   if (cfg_->trajectory.publish_feedback)
     visualization_->publishFeedbackMessage(*this, *obstacles_);
- 
+
 }
 
 
@@ -149,7 +149,7 @@ boost::shared_ptr<g2o::SparseOptimizer> TebOptimalPlanner::initOptimizer()
 {
   // Call register_g2o_types once, even for multiple TebOptimalPlanner instances (thread-safe)
   static boost::once_flag flag = BOOST_ONCE_INIT;
-  boost::call_once(&registerG2OTypes, flag);  
+  boost::call_once(&registerG2OTypes, flag);
 
   // allocating the optimizer
   boost::shared_ptr<g2o::SparseOptimizer> optimizer = boost::make_shared<g2o::SparseOptimizer>();
@@ -159,9 +159,9 @@ boost::shared_ptr<g2o::SparseOptimizer> TebOptimalPlanner::initOptimizer()
   g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg(blockSolver);
 
   optimizer->setAlgorithm(solver);
-  
+
   optimizer->initMultiThreading(); // required for >Eigen 3.1
-  
+
   return optimizer;
 }
 
@@ -169,12 +169,12 @@ boost::shared_ptr<g2o::SparseOptimizer> TebOptimalPlanner::initOptimizer()
 bool TebOptimalPlanner::optimizeTEB(int iterations_innerloop, int iterations_outerloop, bool compute_cost_afterwards,
                                     double obst_cost_scale, double viapoint_cost_scale, bool alternative_time_cost)
 {
-  if (cfg_->optim.optimization_activate==false) 
+  if (cfg_->optim.optimization_activate==false)
     return false;
-  
+
   bool success = false;
   optimized_ = false;
-  
+
   double weight_multiplier = 1.0;
 
   // TODO(roesmann): we introduced the non-fast mode with the support of dynamic obstacles
@@ -182,7 +182,7 @@ bool TebOptimalPlanner::optimizeTEB(int iterations_innerloop, int iterations_out
   //                 however, we have not tested this mode intensively yet, so we keep
   //                 the legacy fast mode as default until we finish our tests.
   bool fast_mode = !cfg_->obstacles.include_dynamic_obstacles;
-  
+
   for(int i=0; i<iterations_outerloop; ++i)
   {
     if (cfg_->trajectory.teb_autosize)
@@ -193,24 +193,24 @@ bool TebOptimalPlanner::optimizeTEB(int iterations_innerloop, int iterations_out
     }
 
     success = buildGraph(weight_multiplier);
-    if (!success) 
+    if (!success)
     {
         clearGraph();
         return false;
     }
     success = optimizeGraph(iterations_innerloop, false);
-    if (!success) 
+    if (!success)
     {
         clearGraph();
         return false;
     }
     optimized_ = true;
-    
+
     if (compute_cost_afterwards && i==iterations_outerloop-1) // compute cost vec only in the last iteration
       computeCurrentCost(obst_cost_scale, viapoint_cost_scale, alternative_time_cost);
-      
+
     clearGraph();
-    
+
     weight_multiplier *= cfg_->optim.weight_adapt_factor;
   }
 
@@ -232,13 +232,13 @@ void TebOptimalPlanner::setVelocityGoal(const geometry_msgs::Twist& vel_goal)
 }
 
 bool TebOptimalPlanner::plan(const std::vector<geometry_msgs::PoseStamped>& initial_plan, const geometry_msgs::Twist* start_vel, bool free_goal_vel)
-{    
+{
   ROS_ASSERT_MSG(initialized_, "Call initialize() first.");
   if (!teb_.isInit())
   {
     // init trajectory
     teb_.initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->trajectory.global_plan_overwrite_orientation, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
-  } 
+  }
   else // warm start
   {
     PoseSE2 start_(initial_plan.front().pose);
@@ -258,7 +258,7 @@ bool TebOptimalPlanner::plan(const std::vector<geometry_msgs::PoseStamped>& init
     setVelocityGoalFree();
   else
     vel_goal_.first = true; // we just reactivate and use the previously set velocity (should be zero if nothing was modified)
-  
+
   // now optimize
   return optimizeTEB(cfg_->optim.no_inner_iterations, cfg_->optim.no_outer_iterations);
 }
@@ -272,7 +272,7 @@ bool TebOptimalPlanner::plan(const tf::Pose& start, const tf::Pose& goal, const 
 }
 
 bool TebOptimalPlanner::plan(const PoseSE2& start, const PoseSE2& goal, const geometry_msgs::Twist* start_vel, bool free_goal_vel)
-{	
+{
   ROS_ASSERT_MSG(initialized_, "Call initialize() first.");
   if (!teb_.isInit())
   {
@@ -296,7 +296,7 @@ bool TebOptimalPlanner::plan(const PoseSE2& start, const PoseSE2& goal, const ge
     setVelocityGoalFree();
   else
     vel_goal_.first = true; // we just reactivate and use the previously set velocity (should be zero if nothing was modified)
-      
+
   // now optimize
   return optimizeTEB(cfg_->optim.no_inner_iterations, cfg_->optim.no_outer_iterations);
 }
@@ -309,10 +309,10 @@ bool TebOptimalPlanner::buildGraph(double weight_multiplier)
     ROS_WARN("Cannot build graph, because it is not empty. Call graphClear()!");
     return false;
   }
-  
+
   // add TEB vertices
   AddTEBVertices();
-  
+
   // add Edges (local cost functions)
   if (cfg_->obstacles.legacy_obstacle_association)
     AddEdgesObstaclesLegacy(weight_multiplier);
@@ -321,24 +321,24 @@ bool TebOptimalPlanner::buildGraph(double weight_multiplier)
 
   if (cfg_->obstacles.include_dynamic_obstacles)
     AddEdgesDynamicObstacles();
-  
+
   AddEdgesViaPoints();
-  
+
   AddEdgesVelocity();
-  
+
   AddEdgesAcceleration();
 
-  AddEdgesTimeOptimal();	
-  
+  AddEdgesTimeOptimal();
+
   if (cfg_->robot.min_turning_radius == 0 || cfg_->optim.weight_kinematics_turning_radius == 0)
     AddEdgesKinematicsDiffDrive(); // we have a differential drive robot
   else
     AddEdgesKinematicsCarlike(); // we have a carlike robot since the turning radius is bounded from below.
 
-    
+
   AddEdgesPreferRotDir();
-    
-  return true;  
+
+  return true;
 }
 
 bool TebOptimalPlanner::optimizeGraph(int no_iterations,bool clear_after)
@@ -347,16 +347,16 @@ bool TebOptimalPlanner::optimizeGraph(int no_iterations,bool clear_after)
   {
     ROS_WARN("optimizeGraph(): Robot Max Velocity is smaller than 0.01m/s. Optimizing aborted...");
     if (clear_after) clearGraph();
-    return false;	
+    return false;
   }
-  
+
   if (!teb_.isInit() || teb_.sizePoses() < cfg_->trajectory.min_samples)
   {
     ROS_WARN("optimizeGraph(): TEB is empty or has too less elements. Skipping optimization.");
     if (clear_after) clearGraph();
-    return false;	
+    return false;
   }
-  
+
   optimizer_->setVerbose(cfg_->optim.optimization_verbose);
   optimizer_->initializeOptimization();
 
@@ -372,8 +372,8 @@ bool TebOptimalPlanner::optimizeGraph(int no_iterations,bool clear_after)
 	return false;
   }
 
-  if (clear_after) clearGraph();	
-    
+  if (clear_after) clearGraph();
+
   return true;
 }
 
@@ -382,7 +382,7 @@ void TebOptimalPlanner::clearGraph()
   // clear optimizer states
   //optimizer.edges().clear(); // optimizer.clear deletes edges!!! Therefore do not run optimizer.edges().clear()
   optimizer_->vertices().clear();  // neccessary, because optimizer->clear deletes pointer-targets (therefore it deletes TEB states!)
-  optimizer_->clear();	
+  optimizer_->clear();
 }
 
 
@@ -401,7 +401,7 @@ void TebOptimalPlanner::AddTEBVertices()
       teb_.TimeDiffVertex(i)->setId(id_counter++);
       optimizer_->addVertex(teb_.TimeDiffVertex(i));
     }
-  } 
+  }
 }
 
 
@@ -409,50 +409,50 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
 {
   if (cfg_->optim.weight_obstacle==0 || weight_multiplier==0 || obstacles_==nullptr )
     return; // if weight equals zero skip adding edges!
-    
-  
+
+
   bool inflated = cfg_->obstacles.inflation_dist > cfg_->obstacles.min_obstacle_dist;
 
   Eigen::Matrix<double,1,1> information;
   information.fill(cfg_->optim.weight_obstacle * weight_multiplier);
-  
+
   Eigen::Matrix<double,2,2> information_inflated;
   information_inflated(0,0) = cfg_->optim.weight_obstacle * weight_multiplier;
   information_inflated(1,1) = cfg_->optim.weight_inflation;
   information_inflated(0,1) = information_inflated(1,0) = 0;
-    
+
   // iterate all teb points (skip first and last)
   for (int i=1; i < teb_.sizePoses()-1; ++i)
-  {    
+  {
       double left_min_dist = std::numeric_limits<double>::max();
       double right_min_dist = std::numeric_limits<double>::max();
       Obstacle* left_obstacle = nullptr;
       Obstacle* right_obstacle = nullptr;
-      
+
       std::vector<Obstacle*> relevant_obstacles;
-      
+
       const Eigen::Vector2d pose_orient = teb_.Pose(i).orientationUnitVec();
-      
+
       // iterate obstacles
       for (const ObstaclePtr& obst : *obstacles_)
       {
-        // we handle dynamic obstacles differently below
-        if(cfg_->obstacles.include_dynamic_obstacles && obst->isDynamic())
-          continue;
+          // we handle dynamic obstacles differently below
+          if(cfg_->obstacles.include_dynamic_obstacles && obst->isDynamic())
+              continue;
 
           // calculate distance to robot model
           double dist = robot_model_->calculateDistance(teb_.Pose(i), obst.get());
-          
+
           // force considering obstacle if really close to the current pose
-        if (dist < cfg_->obstacles.min_obstacle_dist*cfg_->obstacles.obstacle_association_force_inclusion_factor)
+          if (dist < cfg_->obstacles.min_obstacle_dist*cfg_->obstacles.obstacle_association_force_inclusion_factor)
           {
               relevant_obstacles.push_back(obst.get());
               continue;
           }
           // cut-off distance
           if (dist > cfg_->obstacles.min_obstacle_dist*cfg_->obstacles.obstacle_association_cutoff_factor)
-            continue;
-          
+              continue;
+
           // determine side (left or right) and assign obstacle if closer than the previous one
           if (cross2d(pose_orient, obst->getCentroid()) > 0) // left
           {
@@ -470,8 +470,8 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
                   right_obstacle = obst.get();
               }
           }
-      }   
-      
+      }
+
       // create obstacle edges
       if (left_obstacle)
       {
@@ -492,7 +492,7 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
                 optimizer_->addEdge(dist_bandpt_obst);
             }
       }
-      
+
       if (right_obstacle)
       {
             if (inflated)
@@ -510,9 +510,9 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
                 dist_bandpt_obst->setInformation(information);
                 dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), right_obstacle);
                 optimizer_->addEdge(dist_bandpt_obst);
-            }   
+            }
       }
-      
+
       for (const Obstacle* obst : relevant_obstacles)
       {
             if (inflated)
@@ -530,10 +530,10 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
                 dist_bandpt_obst->setInformation(information);
                 dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obst);
                 optimizer_->addEdge(dist_bandpt_obst);
-            }   
+            }
       }
-  }  
-        
+  }
+
 }
 
 
@@ -542,33 +542,33 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
   if (cfg_->optim.weight_obstacle==0 || weight_multiplier==0 || obstacles_==nullptr)
     return; // if weight equals zero skip adding edges!
 
-  Eigen::Matrix<double,1,1> information; 
+  Eigen::Matrix<double,1,1> information;
   information.fill(cfg_->optim.weight_obstacle * weight_multiplier);
-    
+
   Eigen::Matrix<double,2,2> information_inflated;
   information_inflated(0,0) = cfg_->optim.weight_obstacle * weight_multiplier;
   information_inflated(1,1) = cfg_->optim.weight_inflation;
   information_inflated(0,1) = information_inflated(1,0) = 0;
-  
+
   bool inflated = cfg_->obstacles.inflation_dist > cfg_->obstacles.min_obstacle_dist;
-    
+
   for (ObstContainer::const_iterator obst = obstacles_->begin(); obst != obstacles_->end(); ++obst)
   {
     if (cfg_->obstacles.include_dynamic_obstacles && (*obst)->isDynamic()) // we handle dynamic obstacles differently below
-      continue; 
-    
+      continue;
+
     int index;
-    
+
     if (cfg_->obstacles.obstacle_poses_affected >= teb_.sizePoses())
       index =  teb_.sizePoses() / 2;
     else
       index = teb_.findClosestTrajectoryPose(*(obst->get()));
-     
-    
+
+
     // check if obstacle is outside index-range between start and goal
     if ( (index <= 1) || (index > teb_.sizePoses()-2) ) // start and goal are fixed and findNearestBandpoint finds first or last conf if intersection point is outside the range
-	    continue; 
-        
+	    continue;
+
     if (inflated)
     {
         EdgeInflatedObstacle* dist_bandpt_obst = new EdgeInflatedObstacle;
@@ -626,8 +626,8 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
                 optimizer_->addEdge(dist_bandpt_obst_n_l);
             }
       }
-    } 
-    
+    }
+
   }
 }
 
@@ -641,7 +641,7 @@ void TebOptimalPlanner::AddEdgesDynamicObstacles(double weight_multiplier)
   information(0,0) = cfg_->optim.weight_dynamic_obstacle * weight_multiplier;
   information(1,1) = cfg_->optim.weight_dynamic_obstacle_inflation;
   information(0,1) = information(1,0) = 0;
-  
+
   for (ObstContainer::const_iterator obst = obstacles_->begin(); obst != obstacles_->end(); ++obst)
   {
     if (!(*obst)->isDynamic())
@@ -667,20 +667,20 @@ void TebOptimalPlanner::AddEdgesViaPoints()
     return; // if weight equals zero skip adding edges!
 
   int start_pose_idx = 0;
-  
+
   int n = teb_.sizePoses();
   if (n<3) // we do not have any degrees of freedom for reaching via-points
     return;
-  
+
   for (ViaPointContainer::const_iterator vp_it = via_points_->begin(); vp_it != via_points_->end(); ++vp_it)
   {
-    
+
     int index = teb_.findClosestTrajectoryPose(*vp_it, NULL, start_pose_idx);
     if (cfg_->trajectory.via_points_ordered)
       start_pose_idx = index+2; // skip a point to have a DOF inbetween for further via-points
-     
+
     // check if point conicides with goal or is located behind it
-    if ( index > n-2 ) 
+    if ( index > n-2 )
       index = n-2; // set to a pose before the goal, since we can move it away!
     // check if point coincides with start or is located before it
     if ( index < 1)
@@ -697,12 +697,12 @@ void TebOptimalPlanner::AddEdgesViaPoints()
     }
     Eigen::Matrix<double,1,1> information;
     information.fill(cfg_->optim.weight_viapoint);
-    
+
     EdgeViaPoint* edge_viapoint = new EdgeViaPoint;
     edge_viapoint->setVertex(0,teb_.PoseVertex(index));
     edge_viapoint->setInformation(information);
     edge_viapoint->setParameters(*cfg_, &(*vp_it));
-    optimizer_->addEdge(edge_viapoint);   
+    optimizer_->addEdge(edge_viapoint);
   }
 }
 
@@ -735,7 +735,7 @@ void TebOptimalPlanner::AddEdgesVelocity()
   {
     if ( cfg_->optim.weight_max_vel_x==0 && cfg_->optim.weight_max_vel_y==0 && cfg_->optim.weight_max_vel_theta==0)
       return; // if weight equals zero skip adding edges!
-      
+
     int n = teb_.sizePoses();
     Eigen::Matrix<double,3,3> information;
     information.fill(0);
@@ -752,25 +752,25 @@ void TebOptimalPlanner::AddEdgesVelocity()
       velocity_edge->setInformation(information);
       velocity_edge->setTebConfig(*cfg_);
       optimizer_->addEdge(velocity_edge);
-    } 
-    
+    }
+
   }
 }
 
 void TebOptimalPlanner::AddEdgesAcceleration()
 {
-  if (cfg_->optim.weight_acc_lim_x==0  && cfg_->optim.weight_acc_lim_theta==0) 
+  if (cfg_->optim.weight_acc_lim_x==0  && cfg_->optim.weight_acc_lim_theta==0)
     return; // if weight equals zero skip adding edges!
 
-  int n = teb_.sizePoses();  
-    
+  int n = teb_.sizePoses();
+
   if (cfg_->robot.max_vel_y == 0 || cfg_->robot.acc_lim_y == 0) // non-holonomic robot
   {
     Eigen::Matrix<double,2,2> information;
     information.fill(0);
     information(0,0) = cfg_->optim.weight_acc_lim_x;
     information(1,1) = cfg_->optim.weight_acc_lim_theta;
-    
+
     // check if an initial velocity should be taken into accound
     if (vel_start_.first)
     {
@@ -797,7 +797,7 @@ void TebOptimalPlanner::AddEdgesAcceleration()
       acceleration_edge->setTebConfig(*cfg_);
       optimizer_->addEdge(acceleration_edge);
     }
-    
+
     // check if a goal velocity should be taken into accound
     if (vel_goal_.first)
     {
@@ -809,7 +809,7 @@ void TebOptimalPlanner::AddEdgesAcceleration()
       acceleration_edge->setInformation(information);
       acceleration_edge->setTebConfig(*cfg_);
       optimizer_->addEdge(acceleration_edge);
-    }  
+    }
   }
   else // holonomic robot
   {
@@ -818,7 +818,7 @@ void TebOptimalPlanner::AddEdgesAcceleration()
     information(0,0) = cfg_->optim.weight_acc_lim_x;
     information(1,1) = cfg_->optim.weight_acc_lim_y;
     information(2,2) = cfg_->optim.weight_acc_lim_theta;
-    
+
     // check if an initial velocity should be taken into accound
     if (vel_start_.first)
     {
@@ -845,7 +845,7 @@ void TebOptimalPlanner::AddEdgesAcceleration()
       acceleration_edge->setTebConfig(*cfg_);
       optimizer_->addEdge(acceleration_edge);
     }
-    
+
     // check if a goal velocity should be taken into accound
     if (vel_goal_.first)
     {
@@ -857,7 +857,7 @@ void TebOptimalPlanner::AddEdgesAcceleration()
       acceleration_edge->setInformation(information);
       acceleration_edge->setTebConfig(*cfg_);
       optimizer_->addEdge(acceleration_edge);
-    }  
+    }
   }
 }
 
@@ -865,7 +865,7 @@ void TebOptimalPlanner::AddEdgesAcceleration()
 
 void TebOptimalPlanner::AddEdgesTimeOptimal()
 {
-  if (cfg_->optim.weight_optimaltime==0) 
+  if (cfg_->optim.weight_optimaltime==0)
     return; // if weight equals zero skip adding edges!
 
   Eigen::Matrix<double,1,1> information;
@@ -887,22 +887,22 @@ void TebOptimalPlanner::AddEdgesKinematicsDiffDrive()
 {
   if (cfg_->optim.weight_kinematics_nh==0 && cfg_->optim.weight_kinematics_forward_drive==0)
     return; // if weight equals zero skip adding edges!
-  
+
   // create edge for satisfiying kinematic constraints
   Eigen::Matrix<double,2,2> information_kinematics;
   information_kinematics.fill(0.0);
   information_kinematics(0, 0) = cfg_->optim.weight_kinematics_nh;
   information_kinematics(1, 1) = cfg_->optim.weight_kinematics_forward_drive;
-  
+
   for (int i=0; i < teb_.sizePoses()-1; i++) // ignore twiced start only
   {
     EdgeKinematicsDiffDrive* kinematics_edge = new EdgeKinematicsDiffDrive;
     kinematics_edge->setVertex(0,teb_.PoseVertex(i));
-    kinematics_edge->setVertex(1,teb_.PoseVertex(i+1));      
+    kinematics_edge->setVertex(1,teb_.PoseVertex(i+1));
     kinematics_edge->setInformation(information_kinematics);
     kinematics_edge->setTebConfig(*cfg_);
     optimizer_->addEdge(kinematics_edge);
-  }	 
+  }
 }
 
 void TebOptimalPlanner::AddEdgesKinematicsCarlike()
@@ -915,16 +915,16 @@ void TebOptimalPlanner::AddEdgesKinematicsCarlike()
   information_kinematics.fill(0.0);
   information_kinematics(0, 0) = cfg_->optim.weight_kinematics_nh;
   information_kinematics(1, 1) = cfg_->optim.weight_kinematics_turning_radius;
-  
+
   for (int i=0; i < teb_.sizePoses()-1; i++) // ignore twiced start only
   {
     EdgeKinematicsCarlike* kinematics_edge = new EdgeKinematicsCarlike;
     kinematics_edge->setVertex(0,teb_.PoseVertex(i));
-    kinematics_edge->setVertex(1,teb_.PoseVertex(i+1));      
+    kinematics_edge->setVertex(1,teb_.PoseVertex(i+1));
     kinematics_edge->setInformation(information_kinematics);
     kinematics_edge->setTebConfig(*cfg_);
     optimizer_->addEdge(kinematics_edge);
-  }  
+  }
 }
 
 
@@ -949,41 +949,41 @@ void TebOptimalPlanner::AddEdgesPreferRotDir()
   // create edge for satisfiying kinematic constraints
   Eigen::Matrix<double,1,1> information_rotdir;
   information_rotdir.fill(cfg_->optim.weight_prefer_rotdir);
-  
+
   for (int i=0; i < teb_.sizePoses()-1 && i < 3; ++i) // currently: apply to first 3 rotations
   {
     EdgePreferRotDir* rotdir_edge = new EdgePreferRotDir;
     rotdir_edge->setVertex(0,teb_.PoseVertex(i));
-    rotdir_edge->setVertex(1,teb_.PoseVertex(i+1));      
+    rotdir_edge->setVertex(1,teb_.PoseVertex(i+1));
     rotdir_edge->setInformation(information_rotdir);
-    
+
     if (prefer_rotdir_ == RotType::left)
         rotdir_edge->preferLeft();
     else if (prefer_rotdir_ == RotType::right)
         rotdir_edge->preferRight();
-    
+
     optimizer_->addEdge(rotdir_edge);
   }
 }
 
 void TebOptimalPlanner::computeCurrentCost(double obst_cost_scale, double viapoint_cost_scale, bool alternative_time_cost)
-{ 
+{
   // check if graph is empty/exist  -> important if function is called between buildGraph and optimizeGraph/clearGraph
   bool graph_exist_flag(false);
   if (optimizer_->edges().empty() && optimizer_->vertices().empty())
   {
-    // here the graph is build again, for time efficiency make sure to call this function 
+    // here the graph is build again, for time efficiency make sure to call this function
     // between buildGraph and Optimize (deleted), but it depends on the application
-    buildGraph();	
+    buildGraph();
     optimizer_->initializeOptimization();
   }
   else
   {
     graph_exist_flag = true;
   }
-  
+
   optimizer_->computeInitialGuess();
-  
+
   cost_ = 0;
 
   if (alternative_time_cost)
@@ -992,32 +992,73 @@ void TebOptimalPlanner::computeCurrentCost(double obst_cost_scale, double viapoi
     // TEST we use SumOfAllTimeDiffs() here, because edge cost depends on number of samples, which is not always the same for similar TEBs,
     // since we are using an AutoResize Function with hysteresis.
   }
-  
+
   // now we need pointers to all edges -> calculate error for each edge-type
   // since we aren't storing edge pointers, we need to check every edge
   for (std::vector<g2o::OptimizableGraph::Edge*>::const_iterator it = optimizer_->activeEdges().begin(); it!= optimizer_->activeEdges().end(); it++)
   {
     double cur_cost = (*it)->chi2();
 
-    if (dynamic_cast<EdgeObstacle*>(*it) != nullptr
-        || dynamic_cast<EdgeInflatedObstacle*>(*it) != nullptr
-        || dynamic_cast<EdgeDynamicObstacle*>(*it) != nullptr)
+    EdgeKinematicsDiffDrive* edge_kinematics_dd = dynamic_cast<EdgeKinematicsDiffDrive*>(*it);
+    if (edge_kinematics_dd!=NULL)
+    {
+      cost_ += edge_kinematics_dd->getError().squaredNorm();
+      continue;
+    }
+
+    EdgeKinematicsCarlike* edge_kinematics_cl = dynamic_cast<EdgeKinematicsCarlike*>(*it);
+    if (edge_kinematics_cl!=NULL)
+    {
+      cost_ += edge_kinematics_cl->getError().squaredNorm();
+      continue;
+    }
+
+    EdgeVelocity* edge_velocity = dynamic_cast<EdgeVelocity*>(*it);
+    if (edge_velocity!=NULL)
+    {
+      cost_ += edge_velocity->getError().squaredNorm();
+      continue;
+    }
+
+    EdgeAcceleration* edge_acceleration = dynamic_cast<EdgeAcceleration*>(*it);
+    if (edge_acceleration!=NULL)
+    {
+      cost_ += edge_acceleration->getError().squaredNorm();
+      continue;
+    }
+
+    EdgeObstacle* edge_obstacle = dynamic_cast<EdgeObstacle*>(*it);
+    if (edge_obstacle!=NULL)
     {
       cur_cost *= obst_cost_scale;
     }
-    else if (dynamic_cast<EdgeViaPoint*>(*it) != nullptr)
+
+    EdgeInflatedObstacle* edge_inflated_obstacle = dynamic_cast<EdgeInflatedObstacle*>(*it);
+    if (edge_inflated_obstacle!=NULL)
     {
-      cur_cost *= viapoint_cost_scale;
+      cost_ += std::sqrt(std::pow(edge_inflated_obstacle->getError()[0],2) * obst_cost_scale
+               + std::pow(edge_inflated_obstacle->getError()[1],2));
+      continue;
     }
-    else if (dynamic_cast<EdgeTimeOptimal*>(*it) != nullptr && alternative_time_cost)
+
+    EdgeDynamicObstacle* edge_dyn_obstacle = dynamic_cast<EdgeDynamicObstacle*>(*it);
+    if (edge_dyn_obstacle!=NULL)
     {
-      continue; // skip these edges if alternative_time_cost is active
+      cost_ += edge_dyn_obstacle->getError().squaredNorm() * obst_cost_scale;
+      continue;
+    }
+
+    EdgeViaPoint* edge_viapoint = dynamic_cast<EdgeViaPoint*>(*it);
+    if (edge_viapoint!=NULL)
+    {
+      cost_ += edge_viapoint->getError().squaredNorm() * viapoint_cost_scale;
+      continue;
     }
     cost_ += cur_cost;
   }
 
   // delete temporary created graph
-  if (!graph_exist_flag) 
+  if (!graph_exist_flag)
     clearGraph();
 }
 
@@ -1031,9 +1072,9 @@ void TebOptimalPlanner::extractVelocity(const PoseSE2& pose1, const PoseSE2& pos
     omega = 0;
     return;
   }
-  
+
   Eigen::Vector2d deltaS = pose2.position() - pose1.position();
-  
+
   if (cfg_->robot.max_vel_y == 0) // nonholonomic robot
   {
     Eigen::Vector2d conf1dir( cos(pose1.theta()), sin(pose1.theta()) );
@@ -1052,9 +1093,9 @@ void TebOptimalPlanner::extractVelocity(const PoseSE2& pose1, const PoseSE2& pos
     double p1_dx =  cos_theta1*deltaS.x() + sin_theta1*deltaS.y();
     double p1_dy = -sin_theta1*deltaS.x() + cos_theta1*deltaS.y();
     vx = p1_dx / dt;
-    vy = p1_dy / dt;    
+    vy = p1_dy / dt;
   }
-  
+
   // rotational velocity
   double orientdiff = g2o::normalize_theta(pose2.theta() - pose1.theta());
   omega = orientdiff/dt;
@@ -1070,17 +1111,17 @@ bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega
     omega = 0;
     return false;
   }
-  
+
   double dt = teb_.TimeDiff(0);
   if (dt<=0)
-  {	
+  {
     ROS_ERROR("TebOptimalPlanner::getVelocityCommand() - timediff<=0 is invalid!");
     vx = 0;
     vy = 0;
     omega = 0;
     return false;
   }
-	  
+
   // Get velocity from the first two configurations
   extractVelocity(teb_.Pose(0), teb_.Pose(1), dt, vx, vy, omega);
   return true;
@@ -1091,23 +1132,23 @@ void TebOptimalPlanner::getVelocityProfile(std::vector<geometry_msgs::Twist>& ve
   int n = teb_.sizePoses();
   velocity_profile.resize( n+1 );
 
-  // start velocity 
+  // start velocity
   velocity_profile.front().linear.z = 0;
-  velocity_profile.front().angular.x = velocity_profile.front().angular.y = 0;  
+  velocity_profile.front().angular.x = velocity_profile.front().angular.y = 0;
   velocity_profile.front().linear.x = vel_start_.second.linear.x;
   velocity_profile.front().linear.y = vel_start_.second.linear.y;
   velocity_profile.front().angular.z = vel_start_.second.angular.z;
-  
+
   for (int i=1; i<n; ++i)
   {
     velocity_profile[i].linear.z = 0;
     velocity_profile[i].angular.x = velocity_profile[i].angular.y = 0;
     extractVelocity(teb_.Pose(i-1), teb_.Pose(i), teb_.TimeDiff(i-1), velocity_profile[i].linear.x, velocity_profile[i].linear.y, velocity_profile[i].angular.z);
   }
-  
+
   // goal velocity
   velocity_profile.back().linear.z = 0;
-  velocity_profile.back().angular.x = velocity_profile.back().angular.y = 0;  
+  velocity_profile.back().angular.x = velocity_profile.back().angular.y = 0;
   velocity_profile.back().linear.x = vel_goal_.second.linear.x;
   velocity_profile.back().linear.y = vel_goal_.second.linear.y;
   velocity_profile.back().angular.z = vel_goal_.second.angular.z;
@@ -1116,14 +1157,14 @@ void TebOptimalPlanner::getVelocityProfile(std::vector<geometry_msgs::Twist>& ve
 void TebOptimalPlanner::getFullTrajectory(std::vector<TrajectoryPointMsg>& trajectory) const
 {
   int n = teb_.sizePoses();
-  
+
   trajectory.resize(n);
-  
+
   if (n == 0)
     return;
-     
+
   double curr_time = 0;
-  
+
   // start
   TrajectoryPointMsg& start = trajectory.front();
   teb_.Pose(0).toPoseMsg(start.pose);
@@ -1133,9 +1174,9 @@ void TebOptimalPlanner::getFullTrajectory(std::vector<TrajectoryPointMsg>& traje
   start.velocity.linear.y = vel_start_.second.linear.y;
   start.velocity.angular.z = vel_start_.second.angular.z;
   start.time_from_start.fromSec(curr_time);
-  
+
   curr_time += teb_.TimeDiff(0);
-  
+
   // intermediate points
   for (int i=1; i < n-1; ++i)
   {
@@ -1148,12 +1189,12 @@ void TebOptimalPlanner::getFullTrajectory(std::vector<TrajectoryPointMsg>& traje
     extractVelocity(teb_.Pose(i), teb_.Pose(i+1), teb_.TimeDiff(i), vel2_x, vel2_y, omega2);
     point.velocity.linear.x = 0.5*(vel1_x+vel2_x);
     point.velocity.linear.y = 0.5*(vel1_y+vel2_y);
-    point.velocity.angular.z = 0.5*(omega1+omega2);    
+    point.velocity.angular.z = 0.5*(omega1+omega2);
     point.time_from_start.fromSec(curr_time);
-    
+
     curr_time += teb_.TimeDiff(i);
   }
-  
+
   // goal
   TrajectoryPointMsg& goal = trajectory.back();
   teb_.BackPose().toPoseMsg(goal.pose);
@@ -1171,13 +1212,13 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
 {
   if (look_ahead_idx < 0 || look_ahead_idx >= teb().sizePoses())
     look_ahead_idx = teb().sizePoses() - 1;
-  
+
   for (int i=0; i <= look_ahead_idx; ++i)
-  {           
+  {
     if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) < 0 )
       return false;
-    // Checks if the distance between two poses is higher than the robot radius or the orientation diff is bigger than the specified threshold
-    // and interpolates in that case.
+
+    // check if distance between two poses is higher than the robot radius and interpolate in that case
     // (if obstacles are pushing two consecutive poses away, the center between two consecutive poses might coincide with the obstacle ;-)!
     if (i<look_ahead_idx)
     {
@@ -1205,6 +1246,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
           }
         }
       }
+
     }
   }
   return true;
@@ -1215,7 +1257,7 @@ bool TebOptimalPlanner::isHorizonReductionAppropriate(const std::vector<geometry
 {
   if (teb_.sizePoses() < int( 1.5*double(cfg_->trajectory.min_samples) ) ) // trajectory is short already
     return false;
-  
+
   // check if distance is at least 2m long // hardcoded for now
   double dist = 0;
   for (int i=1; i < teb_.sizePoses(); ++i)
@@ -1226,40 +1268,40 @@ bool TebOptimalPlanner::isHorizonReductionAppropriate(const std::vector<geometry
   }
   if (dist <= 2)
     return false;
-  
+
   // check if goal orientation is differing with more than 90° and the horizon is still long enough to exclude parking maneuvers.
   // use case: Sometimes the robot accomplish the following navigation task:
   // 1. wall following 2. 180° curve 3. following along the other side of the wall.
-  // If the trajectory is too long, the trajectory might intersect with the obstace and the optimizer does 
+  // If the trajectory is too long, the trajectory might intersect with the obstace and the optimizer does
   // push the trajectory to the correct side.
   if ( std::abs( g2o::normalize_theta( teb_.Pose(0).theta() - teb_.BackPose().theta() ) ) > M_PI/2)
   {
     ROS_DEBUG("TebOptimalPlanner::isHorizonReductionAppropriate(): Goal orientation - start orientation > 90° ");
     return true;
   }
-  
+
   // check if goal heading deviates more than 90° w.r.t. start orienation
   if (teb_.Pose(0).orientationUnitVec().dot(teb_.BackPose().position() - teb_.Pose(0).position()) < 0)
   {
     ROS_DEBUG("TebOptimalPlanner::isHorizonReductionAppropriate(): Goal heading - start orientation > 90° ");
     return true;
   }
-    
+
   // check ratio: distance along the inital plan and distance of the trajectory (maybe too much is cut off)
   int idx=0; // first get point close to the robot (should be fast if the global path is already pruned!)
   for (; idx < (int)initial_plan.size(); ++idx)
   {
     if ( std::sqrt(std::pow(initial_plan[idx].pose.position.x-teb_.Pose(0).x(), 2) + std::pow(initial_plan[idx].pose.position.y-teb_.Pose(0).y(), 2)) )
       break;
-  } 
+  }
   // now calculate length
   double ref_path_length = 0;
   for (; idx < int(initial_plan.size())-1; ++idx)
   {
-    ref_path_length += std::sqrt(std::pow(initial_plan[idx+1].pose.position.x-initial_plan[idx].pose.position.x, 2) 
+    ref_path_length += std::sqrt(std::pow(initial_plan[idx+1].pose.position.x-initial_plan[idx].pose.position.x, 2)
                      + std::pow(initial_plan[idx+1].pose.position.y-initial_plan[idx].pose.position.y, 2) );
-  } 
-  
+  }
+
   // check distances along the teb trajectory (by the way, we also check if the distance between two poses is > obst_dist)
   double teb_length = 0;
   for (int i = 1; i < teb_.sizePoses(); ++i )
@@ -1277,8 +1319,8 @@ bool TebOptimalPlanner::isHorizonReductionAppropriate(const std::vector<geometry
     ROS_DEBUG("TebOptimalPlanner::isHorizonReductionAppropriate(): Planned trajectory is at least 30° shorter than the initial plan");
     return true;
   }
-  
-  
+
+
   // otherwise we do not suggest shrinking the horizon:
   return false;
 }

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -65,6 +65,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("feasibility_check_no_poses", trajectory.feasibility_check_no_poses, trajectory.feasibility_check_no_poses);
   nh.param("publish_feedback", trajectory.publish_feedback, trajectory.publish_feedback);
   nh.param("min_resolution_collision_check_angular", trajectory.min_resolution_collision_check_angular, trajectory.min_resolution_collision_check_angular);
+  nh.param("control_look_ahead_poses", trajectory.control_look_ahead_poses, trajectory.control_look_ahead_poses);
   
   // Robot
   nh.param("max_vel_x", robot.max_vel_x, robot.max_vel_x);

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -145,9 +145,11 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("viapoints_all_candidates", hcp.viapoints_all_candidates, hcp.viapoints_all_candidates);
   nh.param("visualize_hc_graph", hcp.visualize_hc_graph, hcp.visualize_hc_graph); 
   nh.param("visualize_with_time_as_z_axis_scale", hcp.visualize_with_time_as_z_axis_scale, hcp.visualize_with_time_as_z_axis_scale);
+  nh.param("delete_detours_backwards", hcp.delete_detours_backwards, hcp.delete_detours_backwards);
+  nh.param("detours_orientation_tolerance", hcp.detours_orientation_tolerance, hcp.detours_orientation_tolerance);
+  nh.param("length_start_orientation_vector", hcp.length_start_orientation_vector, hcp.length_start_orientation_vector);
   
   // Recovery
-  
   nh.param("shrink_horizon_backup", recovery.shrink_horizon_backup, recovery.shrink_horizon_backup);
   nh.param("shrink_horizon_min_duration", recovery.shrink_horizon_min_duration, recovery.shrink_horizon_min_duration);
   nh.param("oscillation_recovery", recovery.oscillation_recovery, recovery.oscillation_recovery);

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -382,7 +382,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   }
 
   // Get the velocity command for this sampling interval
-  if (!planner_->getVelocityCommand(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z))
+  if (!planner_->getVelocityCommand(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z, cfg_.trajectory.control_look_ahead_poses))
   {
     planner_->clearPlanner();
     ROS_WARN("TebLocalPlannerROS: velocity command invalid. Resetting planner...");

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -42,6 +42,9 @@
 
 #include <boost/algorithm/string.hpp>
 
+// MBF return codes
+#include <mbf_msgs/ExePathResult.h>
+
 // pluginlib macros
 #include <pluginlib/class_list_macros.h>
 
@@ -54,12 +57,13 @@
 #include "g2o/solvers/cholmod/linear_solver_cholmod.h"
 
 
-// register this planner as a BaseLocalPlanner plugin
+// register this planner both as a BaseLocalPlanner and as a MBF's CostmapController plugin
 PLUGINLIB_EXPORT_CLASS(teb_local_planner::TebLocalPlannerROS, nav_core::BaseLocalPlanner)
+PLUGINLIB_EXPORT_CLASS(teb_local_planner::TebLocalPlannerROS, mbf_costmap_core::CostmapController)
 
 namespace teb_local_planner
 {
-  
+
 
 TebLocalPlannerROS::TebLocalPlannerROS() : costmap_ros_(NULL), tf_(NULL), costmap_model_(NULL),
                                            costmap_converter_loader_("costmap_converter", "costmap_converter::BaseCostmapToPolygons"),
@@ -82,22 +86,22 @@ void TebLocalPlannerROS::initialize(std::string name, tf::TransformListener* tf,
 {
   // check if the plugin is already initialized
   if(!initialized_)
-  {	
+  {
     // create Node Handle with name of plugin (as used in move_base for loading)
     ros::NodeHandle nh("~/" + name);
-	        
+
     // get parameters of TebConfig via the nodehandle and override the default config
-    cfg_.loadRosParamFromNodeHandle(nh);       
-    
+    cfg_.loadRosParamFromNodeHandle(nh);
+
     // reserve some memory for obstacles
     obstacles_.reserve(500);
-        
-    // create visualization instance	
-    visualization_ = TebVisualizationPtr(new TebVisualization(nh, cfg_)); 
-        
+
+    // create visualization instance
+    visualization_ = TebVisualizationPtr(new TebVisualization(nh, cfg_));
+
     // create robot footprint/contour model for optimization
     RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer(nh);
-    
+
     // create the planner instance
     if (cfg_.hcp.enable_homotopy_class_planning)
     {
@@ -109,12 +113,12 @@ void TebLocalPlannerROS::initialize(std::string name, tf::TransformListener* tf,
       planner_ = PlannerInterfacePtr(new TebOptimalPlanner(cfg_, &obstacles_, robot_model, visualization_, &via_points_));
       ROS_INFO("Parallel planning in distinctive topologies disabled.");
     }
-    
+
     // init other variables
     tf_ = tf;
     costmap_ros_ = costmap_ros;
     costmap_ = costmap_ros_->getCostmap(); // locking should be done in MoveBase.
-    
+
     costmap_model_ = boost::make_shared<base_local_planner::CostmapModel>(*costmap_);
 
     global_frame_ = costmap_ros_->getGlobalFrameID();
@@ -133,9 +137,9 @@ void TebLocalPlannerROS::initialize(std::string name, tf::TransformListener* tf,
         costmap_converter_->setOdomTopic(cfg_.odom_topic);
         costmap_converter_->initialize(ros::NodeHandle(nh, "costmap_converter/" + converter_name));
         costmap_converter_->setCostmap2D(costmap_);
-        
+
         costmap_converter_->startWorker(ros::Rate(cfg_.obstacles.costmap_converter_rate), costmap_, cfg_.obstacles.costmap_converter_spin_thread);
-        ROS_INFO_STREAM("Costmap conversion plugin " << cfg_.obstacles.costmap_converter_plugin << " loaded.");        
+        ROS_INFO_STREAM("Costmap conversion plugin " << cfg_.obstacles.costmap_converter_plugin << " loaded.");
       }
       catch(pluginlib::PluginlibException& ex)
       {
@@ -143,14 +147,14 @@ void TebLocalPlannerROS::initialize(std::string name, tf::TransformListener* tf,
         costmap_converter_.reset();
       }
     }
-    else 
+    else
       ROS_INFO("No costmap conversion plugin specified. All occupied costmap cells are treaten as point obstacles.");
-  
-    
+
+
     // Get footprint of the robot and minimum and maximum distance from the center of the robot to its footprint vertices.
     footprint_spec_ = costmap_ros_->getRobotFootprint();
-    costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);    
-    
+    costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);
+
     // init the odom helper to receive the robot's velocity from odom messages
     odom_helper_.setOdomTopic(cfg_.odom_topic);
 
@@ -158,22 +162,22 @@ void TebLocalPlannerROS::initialize(std::string name, tf::TransformListener* tf,
     dynamic_recfg_ = boost::make_shared< dynamic_reconfigure::Server<TebLocalPlannerReconfigureConfig> >(nh);
     dynamic_reconfigure::Server<TebLocalPlannerReconfigureConfig>::CallbackType cb = boost::bind(&TebLocalPlannerROS::reconfigureCB, this, _1, _2);
     dynamic_recfg_->setCallback(cb);
-    
+
     // validate optimization footprint and costmap footprint
     validateFootprints(robot_model->getInscribedRadius(), robot_inscribed_radius_, cfg_.obstacles.min_obstacle_dist);
-        
+
     // setup callback for custom obstacles
     custom_obst_sub_ = nh.subscribe("obstacles", 1, &TebLocalPlannerROS::customObstacleCB, this);
 
     // setup callback for custom via-points
     via_points_sub_ = nh.subscribe("via_points", 1, &TebLocalPlannerROS::customViaPointsCB, this);
-    
+
     // initialize failure detector
     ros::NodeHandle nh_move_base("~");
     double controller_frequency = 5;
     nh_move_base.param("controller_frequency", controller_frequency, controller_frequency);
     failure_detector_.setBufferLength(std::round(cfg_.recovery.oscillation_filter_duration*controller_frequency));
-    
+
     // set initialized flag
     initialized_ = true;
 
@@ -201,41 +205,57 @@ bool TebLocalPlannerROS::setPlan(const std::vector<geometry_msgs::PoseStamped>& 
   global_plan_ = orig_global_plan;
 
   // we do not clear the local planner here, since setPlan is called frequently whenever the global planner updates the plan.
-  // the local planner checks whether it is required to reinitialize the trajectory or not within each velocity computation step.  
-            
+  // the local planner checks whether it is required to reinitialize the trajectory or not within each velocity computation step.
+
   // reset goal_reached_ flag
   goal_reached_ = false;
-  
+
   return true;
 }
 
 
 bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
 {
+  std::string dummy_message;
+  geometry_msgs::PoseStamped dummy_pose;
+  geometry_msgs::TwistStamped dummy_velocity, cmd_vel_stamped;
+  uint32_t outcome = computeVelocityCommands(dummy_pose, dummy_velocity, cmd_vel_stamped, dummy_message);
+  cmd_vel = cmd_vel_stamped.twist;
+  return outcome == mbf_msgs::ExePathResult::SUCCESS;
+}
+
+uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
+                                                     const geometry_msgs::TwistStamped& velocity,
+                                                     geometry_msgs::TwistStamped &cmd_vel,
+                                                     std::string &message)
+{
   // check if plugin initialized
   if(!initialized_)
   {
     ROS_ERROR("teb_local_planner has not been initialized, please call initialize() before using this planner");
-    return false;
+    message = "teb_local_planner has not been initialized";
+    return mbf_msgs::ExePathResult::NOT_INITIALIZED;
   }
 
-  cmd_vel.linear.x = 0;
-  cmd_vel.linear.y = 0;
-  cmd_vel.angular.z = 0;
-  goal_reached_ = false;  
-  
+  static uint32_t seq = 0;
+  cmd_vel.header.seq = seq++;
+  cmd_vel.header.stamp = ros::Time::now();
+  cmd_vel.header.frame_id = robot_base_frame_;
+  cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
+  goal_reached_ = false;
+
   // Get robot pose
   tf::Stamped<tf::Pose> robot_pose;
   costmap_ros_->getRobotPose(robot_pose);
   robot_pose_ = PoseSE2(robot_pose);
-    
+
   // Get robot velocity
   tf::Stamped<tf::Pose> robot_vel_tf;
   odom_helper_.getRobotVel(robot_vel_tf);
   robot_vel_.linear.x = robot_vel_tf.getOrigin().getX();
   robot_vel_.linear.y = robot_vel_tf.getOrigin().getY();
   robot_vel_.angular.z = tf::getYaw(robot_vel_tf.getRotation());
-  
+
   // prune global plan to cut off parts of the past (spatially before the robot)
   pruneGlobalPlan(*tf_, robot_pose, global_plan_);
 
@@ -243,11 +263,12 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   std::vector<geometry_msgs::PoseStamped> transformed_plan;
   int goal_idx;
   tf::StampedTransform tf_plan_to_global;
-  if (!transformGlobalPlan(*tf_, global_plan_, robot_pose, *costmap_, global_frame_, cfg_.trajectory.max_global_plan_lookahead_dist, 
+  if (!transformGlobalPlan(*tf_, global_plan_, robot_pose, *costmap_, global_frame_, cfg_.trajectory.max_global_plan_lookahead_dist,
                            transformed_plan, &goal_idx, &tf_plan_to_global))
   {
     ROS_WARN("Could not transform the global plan to the frame of the controller");
-    return false;
+    message = "Could not transform the global plan to the frame of the controller";
+    return mbf_msgs::ExePathResult::INTERNAL_ERROR;
   }
 
   // update via-points container
@@ -266,32 +287,33 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
     && (!cfg_.goal_tolerance.complete_global_plan || via_points_.size() == 0))
   {
     goal_reached_ = true;
-    return true;
+    return mbf_msgs::ExePathResult::SUCCESS;
   }
-  
-  
+
+
   // check if we should enter any backup mode and apply settings
   configureBackupModes(transformed_plan, goal_idx);
-  
-    
+
+
   // Return false if the transformed global plan is empty
   if (transformed_plan.empty())
   {
     ROS_WARN("Transformed plan is empty. Cannot determine a local plan.");
-    return false;
+    message = "Transformed plan is empty";
+    return mbf_msgs::ExePathResult::INVALID_PATH;
   }
-              
+
   // Get current goal point (last point of the transformed plan)
   tf::Stamped<tf::Pose> goal_point;
   tf::poseStampedMsgToTF(transformed_plan.back(), goal_point);
   robot_goal_.x() = goal_point.getOrigin().getX();
-  robot_goal_.y() = goal_point.getOrigin().getY();      
+  robot_goal_.y() = goal_point.getOrigin().getY();
   if (cfg_.trajectory.global_plan_overwrite_orientation)
   {
     robot_goal_.theta() = estimateLocalGoalOrientation(global_plan_, goal_point, goal_idx, tf_plan_to_global);
     // overwrite/update goal orientation of the transformed plan with the actual goal (enable using the plan as initialization)
     transformed_plan.back().pose.orientation = tf::createQuaternionMsgFromYaw(robot_goal_.theta());
-  }  
+  }
   else
   {
     robot_goal_.theta() = tf::getYaw(goal_point.getRotation());
@@ -303,23 +325,23 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
     transformed_plan.insert(transformed_plan.begin(), geometry_msgs::PoseStamped()); // insert start (not yet initialized)
   }
   tf::poseTFToMsg(robot_pose, transformed_plan.front().pose); // update start;
-    
+
   // clear currently existing obstacles
   obstacles_.clear();
-  
+
   // Update obstacle container with costmap information or polygons provided by a costmap_converter plugin
   if (costmap_converter_)
     updateObstacleContainerWithCostmapConverter();
   else
     updateObstacleContainerWithCostmap();
-  
+
   // also consider custom obstacles (must be called after other updates, since the container is not cleared)
   updateObstacleContainerWithCustomObstacles();
-  
-    
+
+
   // Do not allow config changes during the following optimization step
   boost::mutex::scoped_lock cfg_lock(cfg_.configMutex());
-    
+
   // Now perform the actual planning
 //   bool success = planner_->plan(robot_pose_, robot_goal_, robot_vel_, cfg_.goal_tolerance.free_goal_vel); // straight line init
   bool success = planner_->plan(transformed_plan, &robot_vel_, cfg_.goal_tolerance.free_goal_vel);
@@ -327,13 +349,14 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   {
     planner_->clearPlanner(); // force reinitialization for next time
     ROS_WARN("teb_local_planner was not able to obtain a local plan for the current setting.");
-    
+
     ++no_infeasible_plans_; // increase number of infeasible solutions in a row
     time_last_infeasible_plan_ = ros::Time::now();
-    last_cmd_ = cmd_vel;
-    return false;
+    last_cmd_ = cmd_vel.twist;
+    message = "teb_local_planner was not able to obtain a local plan";
+    return mbf_msgs::ExePathResult::NO_VALID_CMD;
   }
-         
+
   // Check feasibility (but within the first few states only)
   if(cfg_.robot.is_footprint_dynamic)
   {
@@ -345,65 +368,67 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_.trajectory.feasibility_check_no_poses);
   if (!feasible)
   {
-    cmd_vel.linear.x = 0;
-    cmd_vel.linear.y = 0;
-    cmd_vel.angular.z = 0;
-   
+    cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
+
     // now we reset everything to start again with the initialization of new trajectories.
     planner_->clearPlanner();
     ROS_WARN("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...");
-    
+
     ++no_infeasible_plans_; // increase number of infeasible solutions in a row
     time_last_infeasible_plan_ = ros::Time::now();
-    last_cmd_ = cmd_vel;
-    return false;
+    last_cmd_ = cmd_vel.twist;
+    message = "teb_local_planner trajectory is not feasible";
+    return mbf_msgs::ExePathResult::NO_VALID_CMD;
   }
 
   // Get the velocity command for this sampling interval
-  if (!planner_->getVelocityCommand(cmd_vel.linear.x, cmd_vel.linear.y, cmd_vel.angular.z))
+  if (!planner_->getVelocityCommand(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z))
   {
     planner_->clearPlanner();
     ROS_WARN("TebLocalPlannerROS: velocity command invalid. Resetting planner...");
     ++no_infeasible_plans_; // increase number of infeasible solutions in a row
     time_last_infeasible_plan_ = ros::Time::now();
-    last_cmd_ = cmd_vel;
-    return false;
+    last_cmd_ = cmd_vel.twist;
+    message = "teb_local_planner velocity command invalid";
+    return mbf_msgs::ExePathResult::NO_VALID_CMD;
   }
-  
+
   // Saturate velocity, if the optimization results violates the constraints (could be possible due to soft constraints).
-  saturateVelocity(cmd_vel.linear.x, cmd_vel.linear.y, cmd_vel.angular.z, cfg_.robot.max_vel_x, cfg_.robot.max_vel_y,
-                   cfg_.robot.max_vel_theta, cfg_.robot.max_vel_x_backwards);
+  saturateVelocity(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z,
+                   cfg_.robot.max_vel_x, cfg_.robot.max_vel_y, cfg_.robot.max_vel_theta, cfg_.robot.max_vel_x_backwards);
 
   // convert rot-vel to steering angle if desired (carlike robot).
   // The min_turning_radius is allowed to be slighly smaller since it is a soft-constraint
   // and opposed to the other constraints not affected by penalty_epsilon. The user might add a safety margin to the parameter itself.
   if (cfg_.robot.cmd_angle_instead_rotvel)
   {
-    cmd_vel.angular.z = convertTransRotVelToSteeringAngle(cmd_vel.linear.x, cmd_vel.angular.z, cfg_.robot.wheelbase, 0.95*cfg_.robot.min_turning_radius);
-    if (!std::isfinite(cmd_vel.angular.z))
+    cmd_vel.twist.angular.z = convertTransRotVelToSteeringAngle(cmd_vel.twist.linear.x, cmd_vel.twist.angular.z,
+                                                                cfg_.robot.wheelbase, 0.95*cfg_.robot.min_turning_radius);
+    if (!std::isfinite(cmd_vel.twist.angular.z))
     {
-      cmd_vel.linear.x = cmd_vel.linear.y = cmd_vel.angular.z = 0;
-      last_cmd_ = cmd_vel;
+      cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
+      last_cmd_ = cmd_vel.twist;
       planner_->clearPlanner();
       ROS_WARN("TebLocalPlannerROS: Resulting steering angle is not finite. Resetting planner...");
       ++no_infeasible_plans_; // increase number of infeasible solutions in a row
       time_last_infeasible_plan_ = ros::Time::now();
-      return false;
+      message = "teb_local_planner steering angle is not finite";
+      return mbf_msgs::ExePathResult::NO_VALID_CMD;
     }
   }
-  
+
   // a feasible solution should be found, reset counter
   no_infeasible_plans_ = 0;
-  
+
   // store last command (for recovery analysis etc.)
-  last_cmd_ = cmd_vel;
-  
-  // Now visualize everything    
+  last_cmd_ = cmd_vel.twist;
+
+  // Now visualize everything
   planner_->visualize();
   visualization_->publishObstacles(obstacles_);
   visualization_->publishViaPoints(via_points_);
   visualization_->publishGlobalPlan(global_plan_);
-  return true;
+  return mbf_msgs::ExePathResult::SUCCESS;
 }
 
 
@@ -421,12 +446,12 @@ bool TebLocalPlannerROS::isGoalReached()
 
 
 void TebLocalPlannerROS::updateObstacleContainerWithCostmap()
-{  
+{
   // Add costmap obstacles if desired
   if (cfg_.obstacles.include_costmap_obstacles)
   {
     Eigen::Vector2d robot_orient = robot_pose_.orientationUnitVec();
-    
+
     for (unsigned int i=0; i<costmap_->getSizeInCellsX()-1; ++i)
     {
       for (unsigned int j=0; j<costmap_->getSizeInCellsY()-1; ++j)
@@ -435,12 +460,12 @@ void TebLocalPlannerROS::updateObstacleContainerWithCostmap()
         {
           Eigen::Vector2d obs;
           costmap_->mapToWorld(i,j,obs.coeffRef(0), obs.coeffRef(1));
-            
+
           // check if obstacle is interesting (e.g. not far behind the robot)
           Eigen::Vector2d obs_dir = obs-robot_pose_.position();
           if ( obs_dir.dot(robot_orient) < 0 && obs_dir.norm() > cfg_.obstacles.costmap_obstacles_behind_robot_dist  )
             continue;
-            
+
           obstacles_.push_back(ObstaclePtr(new PointObstacle(obs)));
         }
       }
@@ -452,7 +477,7 @@ void TebLocalPlannerROS::updateObstacleContainerWithCostmapConverter()
 {
   if (!costmap_converter_)
     return;
-    
+
   //Get obstacles from costmap converter
   costmap_converter::ObstacleArrayConstPtr obstacles = costmap_converter_->getObstacles();
   if (!obstacles)
@@ -503,14 +528,14 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
   {
     // We only use the global header to specify the obstacle coordinate system instead of individual ones
     Eigen::Affine3d obstacle_to_map_eig;
-    try 
+    try
     {
       tf::StampedTransform obstacle_to_map;
       tf_->waitForTransform(global_frame_, ros::Time(0),
             custom_obstacle_msg_.header.frame_id, ros::Time(0),
             custom_obstacle_msg_.header.frame_id, ros::Duration(0.5));
       tf_->lookupTransform(global_frame_, ros::Time(0),
-          custom_obstacle_msg_.header.frame_id, ros::Time(0), 
+          custom_obstacle_msg_.header.frame_id, ros::Time(0),
           custom_obstacle_msg_.header.frame_id, obstacle_to_map);
       tf::transformTFToEigen(obstacle_to_map, obstacle_to_map_eig);
     }
@@ -519,7 +544,7 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
       ROS_ERROR("%s",ex.what());
       obstacle_to_map_eig.setIdentity();
     }
-    
+
     for (size_t i=0; i<custom_obstacle_msg_.obstacles.size(); ++i)
     {
       if (custom_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 && custom_obstacle_msg_.obstacles.at(i).radius > 0 ) // circle
@@ -576,24 +601,24 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
 void TebLocalPlannerROS::updateViaPointsContainer(const std::vector<geometry_msgs::PoseStamped>& transformed_plan, double min_separation)
 {
   via_points_.clear();
-  
+
   if (min_separation<=0)
     return;
-  
+
   std::size_t prev_idx = 0;
   for (std::size_t i=1; i < transformed_plan.size(); ++i) // skip first one, since we do not need any point before the first min_separation [m]
   {
     // check separation to the previous via-point inserted
     if (distance_points2d( transformed_plan[prev_idx].pose.position, transformed_plan[i].pose.position ) < min_separation)
       continue;
-        
+
     // add via-point
     via_points_.push_back( Eigen::Vector2d( transformed_plan[i].pose.position.x, transformed_plan[i].pose.position.y ) );
     prev_idx = i;
   }
-  
+
 }
-      
+
 Eigen::Vector2d TebLocalPlannerROS::tfPoseToEigenVector2dTransRot(const tf::Pose& tf_vel)
 {
   Eigen::Vector2d vel;
@@ -601,13 +626,13 @@ Eigen::Vector2d TebLocalPlannerROS::tfPoseToEigenVector2dTransRot(const tf::Pose
   vel.coeffRef(1) = tf::getYaw(tf_vel.getRotation());
   return vel;
 }
-      
-      
+
+
 bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const tf::Stamped<tf::Pose>& global_pose, std::vector<geometry_msgs::PoseStamped>& global_plan, double dist_behind_robot)
 {
   if (global_plan.empty())
     return true;
-  
+
   try
   {
     // transform robot pose into the plan frame (we do not wait here, since pruning not crucial, if missed a few times)
@@ -615,9 +640,9 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const 
     tf.lookupTransform(global_plan.front().header.frame_id, global_pose.frame_id_, ros::Time(0), global_to_plan_transform);
     tf::Stamped<tf::Pose> robot;
     robot.setData( global_to_plan_transform * global_pose );
-    
+
     double dist_thresh_sq = dist_behind_robot*dist_behind_robot;
-    
+
     // iterate plan until a pose close the robot is found
     std::vector<geometry_msgs::PoseStamped>::iterator it = global_plan.begin();
     std::vector<geometry_msgs::PoseStamped>::iterator erase_end = it;
@@ -635,7 +660,7 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const 
     }
     if (erase_end == global_plan.end())
       return false;
-    
+
     if (erase_end != global_plan.begin())
       global_plan.erase(global_plan.begin(), erase_end);
   }
@@ -646,7 +671,7 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const 
   }
   return true;
 }
-      
+
 
 bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
                   const tf::Stamped<tf::Pose>& global_pose, const costmap_2d::Costmap2D& costmap, const std::string& global_frame, double max_plan_length,
@@ -658,7 +683,7 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
 
   transformed_plan.clear();
 
-  try 
+  try
   {
     if (global_plan.empty())
     {
@@ -673,7 +698,7 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     plan_pose.header.frame_id, plan_pose.header.stamp,
     plan_pose.header.frame_id, ros::Duration(0.5));
     tf.lookupTransform(global_frame, ros::Time(),
-    plan_pose.header.frame_id, plan_pose.header.stamp, 
+    plan_pose.header.frame_id, plan_pose.header.stamp,
     plan_pose.header.frame_id, plan_to_global_transform);
 
     //let's get the pose of the robot in the frame of the plan
@@ -685,12 +710,12 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
                                      costmap.getSizeInCellsY() * costmap.getResolution() / 2.0);
     dist_threshold *= 0.85; // just consider 85% of the costmap size to better incorporate point obstacle that are
                            // located on the border of the local costmap
-    
+
 
     int i = 0;
     double sq_dist_threshold = dist_threshold * dist_threshold;
     double sq_dist = 1e10;
-    
+
     //we need to loop to a point on the plan that is within a certain distance of the robot
     for(int j=0; j < (int)global_plan.size(); ++j)
     {
@@ -706,12 +731,12 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
         i = j;
       }
     }
-    
+
     tf::Stamped<tf::Pose> tf_pose;
     geometry_msgs::PoseStamped newer_pose;
-    
+
     double plan_length = 0; // check cumulative Euclidean distance along the plan
-    
+
     //now we'll transform until points are outside of our distance threshold
     while(i < (int)global_plan.size() && sq_dist <= sq_dist_threshold && (max_plan_length<=0 || plan_length <= max_plan_length))
     {
@@ -727,14 +752,14 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
       double x_diff = robot_pose.getOrigin().x() - global_plan[i].pose.position.x;
       double y_diff = robot_pose.getOrigin().y() - global_plan[i].pose.position.y;
       sq_dist = x_diff * x_diff + y_diff * y_diff;
-      
+
       // caclulate distance to previous pose
       if (i>0 && max_plan_length>0)
         plan_length += distance_points2d(global_plan[i-1].pose.position, global_plan[i].pose.position);
 
       ++i;
     }
-        
+
     // if we are really close to the goal (<sq_dist_threshold) and the goal is not yet reached (e.g. orientation error >>0)
     // the resulting transformed plan can be empty. In that case we explicitly inject the global goal.
     if (transformed_plan.empty())
@@ -746,7 +771,7 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
       tf::poseStampedTFToMsg(tf_pose, newer_pose);
 
       transformed_plan.push_back(newer_pose);
-      
+
       // Return the index of the current goal point (inside the distance threshold)
       if (current_goal_idx) *current_goal_idx = int(global_plan.size())-1;
     }
@@ -755,7 +780,7 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
       // Return the index of the current goal point (inside the distance threshold)
       if (current_goal_idx) *current_goal_idx = i-1; // subtract 1, since i was increased once before leaving the loop
     }
-    
+
     // Return the transformation from the global plan to the global planning frame if desired
     if (tf_plan_to_global) *tf_plan_to_global = plan_to_global_transform;
   }
@@ -764,12 +789,12 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     ROS_ERROR("No Transform available Error: %s\n", ex.what());
     return false;
   }
-  catch(tf::ConnectivityException& ex) 
+  catch(tf::ConnectivityException& ex)
   {
     ROS_ERROR("Connectivity Error: %s\n", ex.what());
     return false;
   }
-  catch(tf::ExtrapolationException& ex) 
+  catch(tf::ExtrapolationException& ex)
   {
     ROS_ERROR("Extrapolation Error: %s\n", ex.what());
     if (global_plan.size() > 0)
@@ -781,14 +806,14 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
   return true;
 }
 
-    
-      
-      
+
+
+
 double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geometry_msgs::PoseStamped>& global_plan, const tf::Stamped<tf::Pose>& local_goal,
 			        int current_goal_idx, const tf::StampedTransform& tf_plan_to_global, int moving_average_length) const
 {
   int n = (int)global_plan.size();
-  
+
   // check if we are near the global goal already
   if (current_goal_idx > n-moving_average_length-2)
   {
@@ -801,16 +826,16 @@ double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geomet
       tf::Quaternion global_orientation;
       tf::quaternionMsgToTF(global_plan.back().pose.orientation, global_orientation);
       return  tf::getYaw(tf_plan_to_global.getRotation() *  global_orientation );
-    }     
+    }
   }
-  
+
   // reduce number of poses taken into account if the desired number of poses is not available
   moving_average_length = std::min(moving_average_length, n-current_goal_idx-1 ); // maybe redundant, since we have checked the vicinity of the goal before
-  
+
   std::vector<double> candidates;
   tf::Stamped<tf::Pose> tf_pose_k = local_goal;
   tf::Stamped<tf::Pose> tf_pose_kp1;
-  
+
   int range_end = current_goal_idx + moving_average_length;
   for (int i = current_goal_idx; i < range_end; ++i)
   {
@@ -818,36 +843,36 @@ double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geomet
     const geometry_msgs::PoseStamped& pose = global_plan.at(i+1);
     tf::poseStampedMsgToTF(pose, tf_pose_kp1);
     tf_pose_kp1.setData(tf_plan_to_global * tf_pose_kp1);
-      
-    // calculate yaw angle  
+
+    // calculate yaw angle
     candidates.push_back( std::atan2(tf_pose_kp1.getOrigin().getY() - tf_pose_k.getOrigin().getY(),
 			  tf_pose_kp1.getOrigin().getX() - tf_pose_k.getOrigin().getX() ) );
-    
-    if (i<range_end-1) 
+
+    if (i<range_end-1)
       tf_pose_k = tf_pose_kp1;
   }
   return average_angles(candidates);
 }
-      
-      
+
+
 void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y, double max_vel_theta, double max_vel_x_backwards) const
 {
   // Limit translational velocity for forward driving
   if (vx > max_vel_x)
     vx = max_vel_x;
-  
+
   // limit strafing velocity
   if (vy > max_vel_y)
     vy = max_vel_y;
   else if (vy < -max_vel_y)
     vy = -max_vel_y;
-  
+
   // Limit angular velocity
   if (omega > max_vel_theta)
     omega = max_vel_theta;
   else if (omega < -max_vel_theta)
     omega = -max_vel_theta;
-  
+
   // Limit backwards velocity
   if (max_vel_x_backwards<=0)
   {
@@ -856,21 +881,21 @@ void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega,
   else if (vx < -max_vel_x_backwards)
     vx = -max_vel_x_backwards;
 }
-     
-     
+
+
 double TebLocalPlannerROS::convertTransRotVelToSteeringAngle(double v, double omega, double wheelbase, double min_turning_radius) const
 {
   if (omega==0 || v==0)
     return 0;
-    
+
   double radius = v/omega;
-  
+
   if (fabs(radius) < min_turning_radius)
-    radius = double(g2o::sign(radius)) * min_turning_radius; 
+    radius = double(g2o::sign(radius)) * min_turning_radius;
 
   return std::atan(wheelbase / radius);
 }
-     
+
 
 void TebLocalPlannerROS::validateFootprints(double opt_inscribed_radius, double costmap_inscribed_radius, double min_obst_dist)
 {
@@ -879,15 +904,15 @@ void TebLocalPlannerROS::validateFootprints(double opt_inscribed_radius, double 
                   "than the inscribed radius of the robot's footprint in the costmap parameters (%f, including 'footprint_padding'). "
                   "Infeasible optimziation results might occur frequently!", opt_inscribed_radius, min_obst_dist, costmap_inscribed_radius);
 }
-   
-   
-   
+
+
+
 void TebLocalPlannerROS::configureBackupModes(std::vector<geometry_msgs::PoseStamped>& transformed_plan,  int& goal_idx)
 {
     ros::Time current_time = ros::Time::now();
-    
+
     // reduced horizon backup mode
-    if (cfg_.recovery.shrink_horizon_backup && 
+    if (cfg_.recovery.shrink_horizon_backup &&
         goal_idx < (int)transformed_plan.size()-1 && // we do not reduce if the goal is already selected (because the orientation might change -> can introduce oscillations)
        (no_infeasible_plans_>0 || (current_time - time_last_infeasible_plan_).toSec() < cfg_.recovery.shrink_horizon_min_duration )) // keep short horizon for at least a few seconds
     {
@@ -897,25 +922,25 @@ void TebLocalPlannerROS::configureBackupModes(std::vector<geometry_msgs::PoseSta
         // Shorten horizon if requested
         // reduce to 50 percent:
         int horizon_reduction = goal_idx/2;
-        
+
         if (no_infeasible_plans_ > 9)
         {
             ROS_INFO_COND(no_infeasible_plans_==10, "Infeasible trajectory detected 10 times in a row: further reducing horizon...");
             horizon_reduction /= 2;
         }
-        
+
         // we have a small overhead here, since we already transformed 50% more of the trajectory.
-        // But that's ok for now, since we do not need to make transformGlobalPlan more complex 
+        // But that's ok for now, since we do not need to make transformGlobalPlan more complex
         // and a reduced horizon should occur just rarely.
         int new_goal_idx_transformed_plan = int(transformed_plan.size()) - horizon_reduction - 1;
         goal_idx -= horizon_reduction;
         if (new_goal_idx_transformed_plan>0 && goal_idx >= 0)
             transformed_plan.erase(transformed_plan.begin()+new_goal_idx_transformed_plan, transformed_plan.end());
         else
-            goal_idx += horizon_reduction; // this should not happen, but safety first ;-) 
+            goal_idx += horizon_reduction; // this should not happen, but safety first ;-)
     }
-    
-    
+
+
     // detect and resolve oscillations
     if (cfg_.recovery.oscillation_recovery)
     {
@@ -925,13 +950,13 @@ void TebLocalPlannerROS::configureBackupModes(std::vector<geometry_msgs::PoseSta
             max_vel_theta = std::max( max_vel_current/std::abs(cfg_.robot.min_turning_radius),  cfg_.robot.max_vel_theta );
         else
             max_vel_theta = cfg_.robot.max_vel_theta;
-        
+
         failure_detector_.update(last_cmd_, cfg_.robot.max_vel_x, cfg_.robot.max_vel_x_backwards, max_vel_theta,
                                cfg_.recovery.oscillation_v_eps, cfg_.recovery.oscillation_omega_eps);
-        
+
         bool oscillating = failure_detector_.isOscillating();
         bool recently_oscillated = (ros::Time::now()-time_last_oscillation_).toSec() < cfg_.recovery.oscillation_recovery_min_duration; // check if we have already detected an oscillation recently
-        
+
         if (oscillating)
         {
             if (!recently_oscillated)
@@ -943,7 +968,7 @@ void TebLocalPlannerROS::configureBackupModes(std::vector<geometry_msgs::PoseSta
                     last_preferred_rotdir_ = RotType::right;
                 ROS_WARN("TebLocalPlannerROS: possible oscillation (of the robot or its local plan) detected. Activating recovery strategy (prefer current turning direction during optimization).");
             }
-            time_last_oscillation_ = ros::Time::now();  
+            time_last_oscillation_ = ros::Time::now();
             planner_->setPreferredTurningDir(last_preferred_rotdir_);
         }
         else if (!recently_oscillated && last_preferred_rotdir_ != RotType::none) // clear recovery behavior
@@ -955,12 +980,12 @@ void TebLocalPlannerROS::configureBackupModes(std::vector<geometry_msgs::PoseSta
     }
 
 }
-     
-     
+
+
 void TebLocalPlannerROS::customObstacleCB(const costmap_converter::ObstacleArrayMsg::ConstPtr& obst_msg)
 {
   boost::mutex::scoped_lock l(custom_obst_mutex_);
-  custom_obstacle_msg_ = *obst_msg;  
+  custom_obstacle_msg_ = *obst_msg;
 }
 
 void TebLocalPlannerROS::customViaPointsCB(const nav_msgs::Path::ConstPtr& via_points_msg)
@@ -982,23 +1007,23 @@ void TebLocalPlannerROS::customViaPointsCB(const nav_msgs::Path::ConstPtr& via_p
   }
   custom_via_points_active_ = !via_points_.empty();
 }
-     
+
 RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(const ros::NodeHandle& nh)
 {
-  std::string model_name; 
+  std::string model_name;
   if (!nh.getParam("footprint_model/type", model_name))
   {
     ROS_INFO("No robot footprint model specified for trajectory optimization. Using point-shaped model.");
     return boost::make_shared<PointRobotFootprint>();
   }
-    
-  // point  
+
+  // point
   if (model_name.compare("point") == 0)
   {
     ROS_INFO("Footprint model 'point' loaded for trajectory optimization.");
     return boost::make_shared<PointRobotFootprint>();
   }
-  
+
   // circular
   if (model_name.compare("circular") == 0)
   {
@@ -1006,21 +1031,21 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(cons
     double radius;
     if (!nh.getParam("footprint_model/radius", radius))
     {
-      ROS_ERROR_STREAM("Footprint model 'circular' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace() 
+      ROS_ERROR_STREAM("Footprint model 'circular' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace()
                        << "/footprint_model/radius' does not exist. Using point-model instead.");
       return boost::make_shared<PointRobotFootprint>();
     }
     ROS_INFO_STREAM("Footprint model 'circular' (radius: " << radius <<"m) loaded for trajectory optimization.");
     return boost::make_shared<CircularRobotFootprint>(radius);
   }
-  
+
   // line
   if (model_name.compare("line") == 0)
   {
     // check parameters
     if (!nh.hasParam("footprint_model/line_start") || !nh.hasParam("footprint_model/line_end"))
     {
-      ROS_ERROR_STREAM("Footprint model 'line' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace() 
+      ROS_ERROR_STREAM("Footprint model 'line' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace()
                        << "/footprint_model/line_start' and/or '.../line_end' do not exist. Using point-model instead.");
       return boost::make_shared<PointRobotFootprint>();
     }
@@ -1030,21 +1055,21 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(cons
     nh.getParam("footprint_model/line_end", line_end);
     if (line_start.size() != 2 || line_end.size() != 2)
     {
-      ROS_ERROR_STREAM("Footprint model 'line' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace() 
+      ROS_ERROR_STREAM("Footprint model 'line' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace()
                        << "/footprint_model/line_start' and/or '.../line_end' do not contain x and y coordinates (2D). Using point-model instead.");
       return boost::make_shared<PointRobotFootprint>();
     }
-    
+
     ROS_INFO_STREAM("Footprint model 'line' (line_start: [" << line_start[0] << "," << line_start[1] <<"]m, line_end: ["
                      << line_end[0] << "," << line_end[1] << "]m) loaded for trajectory optimization.");
     return boost::make_shared<LineRobotFootprint>(Eigen::Map<const Eigen::Vector2d>(line_start.data()), Eigen::Map<const Eigen::Vector2d>(line_end.data()));
   }
-  
+
   // two circles
   if (model_name.compare("two_circles") == 0)
   {
     // check parameters
-    if (!nh.hasParam("footprint_model/front_offset") || !nh.hasParam("footprint_model/front_radius") 
+    if (!nh.hasParam("footprint_model/front_offset") || !nh.hasParam("footprint_model/front_radius")
         || !nh.hasParam("footprint_model/rear_offset") || !nh.hasParam("footprint_model/rear_radius"))
     {
       ROS_ERROR_STREAM("Footprint model 'two_circles' cannot be loaded for trajectory optimization, since params '" << nh.getNamespace()
@@ -1056,7 +1081,7 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(cons
     nh.getParam("footprint_model/front_radius", front_radius);
     nh.getParam("footprint_model/rear_offset", rear_offset);
     nh.getParam("footprint_model/rear_radius", rear_radius);
-    ROS_INFO_STREAM("Footprint model 'two_circles' (front_offset: " << front_offset <<"m, front_radius: " << front_radius 
+    ROS_INFO_STREAM("Footprint model 'two_circles' (front_offset: " << front_offset <<"m, front_radius: " << front_radius
                     << "m, rear_offset: " << rear_offset << "m, rear_radius: " << rear_radius << "m) loaded for trajectory optimization.");
     return boost::make_shared<TwoCirclesRobotFootprint>(front_offset, front_radius, rear_offset, rear_radius);
   }
@@ -1069,7 +1094,7 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(cons
     XmlRpc::XmlRpcValue footprint_xmlrpc;
     if (!nh.getParam("footprint_model/vertices", footprint_xmlrpc) )
     {
-      ROS_ERROR_STREAM("Footprint model 'polygon' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace() 
+      ROS_ERROR_STREAM("Footprint model 'polygon' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace()
                        << "/footprint_model/vertices' does not exist. Using point-model instead.");
       return boost::make_shared<PointRobotFootprint>();
     }
@@ -1081,7 +1106,7 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(cons
         Point2dContainer polygon = makeFootprintFromXMLRPC(footprint_xmlrpc, "/footprint_model/vertices");
         ROS_INFO_STREAM("Footprint model 'polygon' loaded for trajectory optimization.");
         return boost::make_shared<PolygonRobotFootprint>(polygon);
-      } 
+      }
       catch(const std::exception& ex)
       {
         ROS_ERROR_STREAM("Footprint model 'polygon' cannot be loaded for trajectory optimization: " << ex.what() << ". Using point-model instead.");
@@ -1090,21 +1115,21 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(cons
     }
     else
     {
-      ROS_ERROR_STREAM("Footprint model 'polygon' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace() 
+      ROS_ERROR_STREAM("Footprint model 'polygon' cannot be loaded for trajectory optimization, since param '" << nh.getNamespace()
                        << "/footprint_model/vertices' does not define an array of coordinates. Using point-model instead.");
       return boost::make_shared<PointRobotFootprint>();
     }
-    
+
   }
-  
+
   // otherwise
   ROS_WARN_STREAM("Unknown robot footprint model specified with parameter '" << nh.getNamespace() << "/footprint_model/type'. Using point model instead.");
   return boost::make_shared<PointRobotFootprint>();
 }
-         
-       
-       
-       
+
+
+
+
 Point2dContainer TebLocalPlannerROS::makeFootprintFromXMLRPC(XmlRpc::XmlRpcValue& footprint_xmlrpc, const std::string& full_param_name)
 {
    // Make sure we have an array of at least 3 elements.
@@ -1116,10 +1141,10 @@ Point2dContainer TebLocalPlannerROS::makeFootprintFromXMLRPC(XmlRpc::XmlRpcValue
      throw std::runtime_error("The footprint must be specified as list of lists on the parameter server with at least "
                               "3 points eg: [[x1, y1], [x2, y2], ..., [xn, yn]]");
    }
- 
+
    Point2dContainer footprint;
    Eigen::Vector2d pt;
- 
+
    for (int i = 0; i < footprint_xmlrpc.size(); ++i)
    {
      // Make sure each element of the list is an array of size 2. (x and y coordinates)

--- a/src/timed_elastic_band.cpp
+++ b/src/timed_elastic_band.cpp
@@ -547,46 +547,6 @@ int TimedElasticBand::findClosestTrajectoryPose(const Obstacle& obstacle, double
 }
 
 
-
-
-bool TimedElasticBand::detectDetoursBackwards(double threshold) const
-{
-  if (sizePoses()<2) return false;
-  
-  Eigen::Vector2d d_start_goal = BackPose().position() - Pose(0).position();
-  d_start_goal.normalize(); // using scalar_product without normalizing vectors first result in different threshold-effects
-
-  /// detect based on orientation
-  for(int i=0; i < sizePoses(); ++i)
-  {
-    Eigen::Vector2d orient_vector(cos( Pose(i).theta() ), sin( Pose(i).theta() ) );
-    if (orient_vector.dot(d_start_goal) < threshold)
-    {	
-      ROS_DEBUG("detectDetoursBackwards() - mark TEB for deletion: start-orientation vs startgoal-vec");
-      return true; // backward direction found
-    }
-  }
-  
-  /// check if upcoming configuration (next index) ist pushed behind the start (e.g. due to obstacles)
-  // TODO: maybe we need a small hysteresis?
-/*  for (unsigned int i=0;i<2;++i) // check only a few upcoming
-  {
-    if (i+1 >= sizePoses()) break;
-    Eigen::Vector2d start2conf = Pose(i+1).position() - Pose(0).position();
-    double dist = start2conf.norm();
-    start2conf = start2conf/dist; // normalize -> we don't use start2conf.normalize() since we want to use dist later
-    if (start2conf.dot(d_start_goal) < threshold && dist>0.01) // skip very small displacements
-    {
-      ROS_DEBUG("detectDetoursBackwards() - mark TEB for deletion: curvature look-ahead relative to startconf");
-      return true;
-    }
-  }*/	
-  return false;
-}
-
-
-
-
 void TimedElasticBand::updateAndPruneTEB(boost::optional<const PoseSE2&> new_start, boost::optional<const PoseSE2&> new_goal, int min_samples)
 {
   // first and simple approach: change only start confs (and virtual start conf for inital velocity)

--- a/src/visualization.cpp
+++ b/src/visualization.cpp
@@ -56,18 +56,18 @@ void TebVisualization::initialize(ros::NodeHandle& nh, const TebConfig& cfg)
 {
   if (initialized_)
     ROS_WARN("TebVisualization already initialized. Reinitalizing...");
-  
+
   // set config
   cfg_ = &cfg;
-  
+
   // register topics
   global_plan_pub_ = nh.advertise<nav_msgs::Path>("global_plan", 1);
   local_plan_pub_ = nh.advertise<nav_msgs::Path>("local_plan",1);
   teb_poses_pub_ = nh.advertise<geometry_msgs::PoseArray>("teb_poses", 100);
   teb_marker_pub_ = nh.advertise<visualization_msgs::Marker>("teb_markers", 1000);
-  feedback_pub_ = nh.advertise<teb_local_planner::FeedbackMsg>("teb_feedback", 10);  
-  
-  initialized_ = true; 
+  feedback_pub_ = nh.advertise<teb_local_planner::FeedbackMsg>("teb_feedback", 10);
+
+  initialized_ = true;
 }
 
 
@@ -75,31 +75,31 @@ void TebVisualization::initialize(ros::NodeHandle& nh, const TebConfig& cfg)
 void TebVisualization::publishGlobalPlan(const std::vector<geometry_msgs::PoseStamped>& global_plan) const
 {
   if ( printErrorWhenNotInitialized() ) return;
-  base_local_planner::publishPlan(global_plan, global_plan_pub_); 
+  base_local_planner::publishPlan(global_plan, global_plan_pub_);
 }
 
 void TebVisualization::publishLocalPlan(const std::vector<geometry_msgs::PoseStamped>& local_plan) const
 {
   if ( printErrorWhenNotInitialized() )
     return;
-  base_local_planner::publishPlan(local_plan, local_plan_pub_); 
+  base_local_planner::publishPlan(local_plan, local_plan_pub_);
 }
 
 void TebVisualization::publishLocalPlanAndPoses(const TimedElasticBand& teb) const
 {
   if ( printErrorWhenNotInitialized() )
     return;
-  
+
     // create path msg
     nav_msgs::Path teb_path;
     teb_path.header.frame_id = cfg_->map_frame;
     teb_path.header.stamp = ros::Time::now();
-    
+
     // create pose_array (along trajectory)
     geometry_msgs::PoseArray teb_poses;
     teb_poses.header.frame_id = teb_path.header.frame_id;
     teb_poses.header.stamp = teb_path.header.stamp;
-    
+
     // fill path msgs with teb configurations
     for (int i=0; i < teb.sizePoses(); i++)
     {
@@ -123,12 +123,12 @@ void TebVisualization::publishRobotFootprintModel(const PoseSE2& current_pose, c
 {
   if ( printErrorWhenNotInitialized() )
     return;
-  
+
   std::vector<visualization_msgs::Marker> markers;
   robot_model.visualizeRobot(current_pose, markers);
   if (markers.empty())
     return;
-  
+
   int idx = 1000000;  // avoid overshadowing by obstacles
   for (std::vector<visualization_msgs::Marker>::iterator marker_it = markers.begin(); marker_it != markers.end(); ++marker_it, ++idx)
   {
@@ -140,7 +140,6 @@ void TebVisualization::publishRobotFootprintModel(const PoseSE2& current_pose, c
     marker_it->lifetime = ros::Duration(2.0);
     teb_marker_pub_.publish(*marker_it);
   }
-  
 }
 
 
@@ -148,7 +147,7 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
 {
   if ( obstacles.empty() || printErrorWhenNotInitialized() )
     return;
-  
+
   // Visualize point obstacles
   {
     visualization_msgs::Marker marker;
@@ -159,10 +158,10 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
     marker.type = visualization_msgs::Marker::POINTS;
     marker.action = visualization_msgs::Marker::ADD;
     marker.lifetime = ros::Duration(2.0);
-    
+
     for (ObstContainer::const_iterator obst = obstacles.begin(); obst != obstacles.end(); ++obst)
     {
-      boost::shared_ptr<PointObstacle> pobst = boost::dynamic_pointer_cast<PointObstacle>(*obst);      
+      boost::shared_ptr<PointObstacle> pobst = boost::dynamic_pointer_cast<PointObstacle>(*obst);
       if (!pobst)
         continue;
 
@@ -193,7 +192,7 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
         marker.points.push_back(end);
       }
     }
-    
+
     marker.scale.x = 0.1;
     marker.scale.y = 0.1;
     marker.color.a = 1.0;
@@ -203,16 +202,16 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
 
     teb_marker_pub_.publish( marker );
   }
-  
+
   // Visualize line obstacles
   {
     std::size_t idx = 0;
     for (ObstContainer::const_iterator obst = obstacles.begin(); obst != obstacles.end(); ++obst)
-    {	
-      boost::shared_ptr<LineObstacle> pobst = boost::dynamic_pointer_cast<LineObstacle>(*obst);   
+    {
+      boost::shared_ptr<LineObstacle> pobst = boost::dynamic_pointer_cast<LineObstacle>(*obst);
       if (!pobst)
         continue;
-      
+
       visualization_msgs::Marker marker;
       marker.header.frame_id = cfg_->map_frame;
       marker.header.stamp = ros::Time::now();
@@ -231,28 +230,28 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
       end.y = pobst->end().y();
       end.z = 0;
       marker.points.push_back(end);
-  
+
       marker.scale.x = 0.1;
       marker.scale.y = 0.1;
       marker.color.a = 1.0;
       marker.color.r = 0.0;
       marker.color.g = 1.0;
       marker.color.b = 0.0;
-      
-      teb_marker_pub_.publish( marker );     
+
+      teb_marker_pub_.publish( marker );
     }
   }
-  
+
 
   // Visualize polygon obstacles
   {
     std::size_t idx = 0;
     for (ObstContainer::const_iterator obst = obstacles.begin(); obst != obstacles.end(); ++obst)
-    {	
-      boost::shared_ptr<PolygonObstacle> pobst = boost::dynamic_pointer_cast<PolygonObstacle>(*obst);   
+    {
+      boost::shared_ptr<PolygonObstacle> pobst = boost::dynamic_pointer_cast<PolygonObstacle>(*obst);
       if (!pobst)
 				continue;
-      
+
       visualization_msgs::Marker marker;
       marker.header.frame_id = cfg_->map_frame;
       marker.header.stamp = ros::Time::now();
@@ -261,7 +260,7 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
       marker.type = visualization_msgs::Marker::LINE_STRIP;
       marker.action = visualization_msgs::Marker::ADD;
       marker.lifetime = ros::Duration(2.0);
-      
+
       for (Point2dContainer::const_iterator vertex = pobst->vertices().begin(); vertex != pobst->vertices().end(); ++vertex)
       {
         geometry_msgs::Point point;
@@ -270,7 +269,7 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
         point.z = 0;
         marker.points.push_back(point);
       }
-      
+
       // Also add last point to close the polygon
       // but only if polygon has more than 2 points (it is not a line)
       if (pobst->vertices().size() > 2)
@@ -287,8 +286,8 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
       marker.color.r = 1.0;
       marker.color.g = 0.0;
       marker.color.b = 0.0;
-      
-      teb_marker_pub_.publish( marker );     
+
+      teb_marker_pub_.publish( marker );
     }
   }
 }
@@ -298,7 +297,7 @@ void TebVisualization::publishViaPoints(const std::vector< Eigen::Vector2d, Eige
 {
   if ( via_points.empty() || printErrorWhenNotInitialized() )
     return;
-  
+
   visualization_msgs::Marker marker;
   marker.header.frame_id = cfg_->map_frame;
   marker.header.stamp = ros::Time::now();
@@ -307,7 +306,7 @@ void TebVisualization::publishViaPoints(const std::vector< Eigen::Vector2d, Eige
   marker.type = visualization_msgs::Marker::POINTS;
   marker.action = visualization_msgs::Marker::ADD;
   marker.lifetime = ros::Duration(2.0);
-  
+
   for (std::size_t i=0; i < via_points.size(); ++i)
   {
     geometry_msgs::Point point;
@@ -316,7 +315,7 @@ void TebVisualization::publishViaPoints(const std::vector< Eigen::Vector2d, Eige
     point.z = 0;
     marker.points.push_back(point);
   }
-  
+
   marker.scale.x = 0.1;
   marker.scale.y = 0.1;
   marker.color.a = 1.0;
@@ -331,7 +330,7 @@ void TebVisualization::publishTebContainer(const TebOptPlannerContainer& teb_pla
 {
 if ( printErrorWhenNotInitialized() )
     return;
-  
+
   visualization_msgs::Marker marker;
   marker.header.frame_id = cfg_->map_frame;
   marker.header.stamp = ros::Time::now();
@@ -339,10 +338,10 @@ if ( printErrorWhenNotInitialized() )
   marker.id = 0;
   marker.type = visualization_msgs::Marker::LINE_LIST;
   marker.action = visualization_msgs::Marker::ADD;
-  
+
   // Iterate through teb pose sequence
   for( TebOptPlannerContainer::const_iterator it_teb = teb_planner.begin(); it_teb != teb_planner.end(); ++it_teb )
-  {	  
+  {
     // iterate single poses
     PoseSequence::const_iterator it_pose = it_teb->get()->teb().poses().begin();
     TimeDiffSequence::const_iterator it_timediff = it_teb->get()->teb().timediffs().begin();
@@ -385,18 +384,18 @@ void TebVisualization::publishFeedbackMessage(const std::vector< boost::shared_p
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = cfg_->map_frame;
   msg.selected_trajectory_idx = selected_trajectory_idx;
-  
-  
+
+
   msg.trajectories.resize(teb_planners.size());
-  
+
   // Iterate through teb pose sequence
   std::size_t idx_traj = 0;
   for( TebOptPlannerContainer::const_iterator it_teb = teb_planners.begin(); it_teb != teb_planners.end(); ++it_teb, ++idx_traj )
-  {   
+  {
     msg.trajectories[idx_traj].header = msg.header;
     it_teb->get()->getFullTrajectory(msg.trajectories[idx_traj].trajectory);
   }
-  
+
   // add obstacles
   msg.obstacles_msg.obstacles.resize(obstacles.size());
   for (std::size_t i=0; i<obstacles.size(); ++i)
@@ -416,7 +415,7 @@ void TebVisualization::publishFeedbackMessage(const std::vector< boost::shared_p
     // copy velocities
     obstacles[i]->toTwistWithCovarianceMsg(msg.obstacles_msg.obstacles[i].velocities);
   }
-  
+
   feedback_pub_.publish(msg);
 }
 
@@ -426,11 +425,11 @@ void TebVisualization::publishFeedbackMessage(const TebOptimalPlanner& teb_plann
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = cfg_->map_frame;
   msg.selected_trajectory_idx = 0;
-  
+
   msg.trajectories.resize(1);
   msg.trajectories.front().header = msg.header;
   teb_planner.getFullTrajectory(msg.trajectories.front().trajectory);
- 
+
   // add obstacles
   msg.obstacles_msg.obstacles.resize(obstacles.size());
   for (std::size_t i=0; i<obstacles.size(); ++i)
@@ -450,7 +449,7 @@ void TebVisualization::publishFeedbackMessage(const TebOptimalPlanner& teb_plann
     // copy velocities
     obstacles[i]->toTwistWithCovarianceMsg(msg.obstacles_msg.obstacles[i].velocities);
   }
-  
+
   feedback_pub_.publish(msg);
 }
 

--- a/teb_local_planner_plugin.xml
+++ b/teb_local_planner_plugin.xml
@@ -5,5 +5,10 @@
 			to the base_local_planner of the 2D navigation stack.
 		</description>
 	</class>
+	<class name="teb_local_planner/TebLocalPlannerROS" type="teb_local_planner::TebLocalPlannerROS" base_class_type="mbf_costmap_core::CostmapController">
+		<description>
+			Same plugin implemented MBF CostmapController's extended interface.
+		</description>
+	</class>
 </library>
 


### PR DESCRIPTION
Shifting the control pose in the future reduces the control bandwidth and hence makes the control "less nervous", avoiding wobbles while following straight trajectories.