### PR TITLE
Fix back and forth trajectory for a closer goal

### DIFF
--- a/src/timed_elastic_band.cpp
+++ b/src/timed_elastic_band.cpp
@@ -614,17 +614,15 @@ void TimedElasticBand::updateAndPruneTEB(boost::optional<const PoseSE2&> new_sta
   if (new_goal && sizePoses()>0)
   {
     // find nearest state (using l2-norm) in order to prune the end of the trajectory.
-    double lookback_traj_length = 0.;
-    
-    double min_distance_to_teb = std::numeric_limits<double>::max();
-    int min_distance_to_teb_idx = sizePoses() - 1;
+    double dist_cache = std::numeric_limits<double>::max();
+    int nearest_idx = sizePoses() - 1;
     for (int i = sizePoses()-1; i > min_samples; --i)
     {
       double dist = (new_goal->position()- Pose(i).position()).norm();
-      if (dist <= min_distance_to_teb)
+      if (dist <= dist_cache)
       {
-        min_distance_to_teb = dist;
-        min_distance_to_teb_idx = i;
+        dist_cache = dist;
+        nearest_idx = i;
       }
       else
       {
@@ -633,11 +631,11 @@ void TimedElasticBand::updateAndPruneTEB(boost::optional<const PoseSE2&> new_sta
     }
     
     // prune trajectory at the end and replace last one with the goal
-    if (min_distance_to_teb_idx < sizePoses() - 1)
+    if (nearest_idx < sizePoses() - 1)
     {
-      const int num_elems_to_delete = sizePoses() - min_distance_to_teb_idx - 1;
-      deletePoses(min_distance_to_teb_idx, num_elems_to_delete);
-      deleteTimeDiffs(min_distance_to_teb_idx, num_elems_to_delete);
+      const int num_elems_to_delete = sizePoses() - nearest_idx - 1;
+      deletePoses(nearest_idx, num_elems_to_delete);
+      deleteTimeDiffs(nearest_idx, num_elems_to_delete);
     }
     BackPose() = *new_goal;
   }

--- a/test/teb_basics.cpp
+++ b/test/teb_basics.cpp
@@ -66,6 +66,32 @@ TEST(TEBBasic, autoResize)
   }
 }
 
+TEST(TEBBasic, updateAndPruneWithCloserGoal)
+{
+  const double dt = 0.1;
+  teb_local_planner::TimedElasticBand teb;
+
+  // setup a simple TEB (straight line)
+  teb.addPose(teb_local_planner::PoseSE2(0., 0., 0.));
+  for (int i = 1; i < 10; ++i)
+  {
+    teb.addPoseAndTimeDiff(teb_local_planner::PoseSE2(i * 1., 0., 0.), dt * i);
+  }
+
+  // update with a goal that is now closer to the robot but on the old path
+  const teb_local_planner::PoseSE2 new_start(0., 0., 0.);
+  const teb_local_planner::PoseSE2 new_goal(7.1, 0., 0.);
+  const int min_samples = 3;
+
+  teb.updateAndPruneTEB(new_start, new_goal, min_samples);
+
+  ASSERT_EQ(8, teb.sizePoses()); // expect to remove poses
+  ASSERT_FLOAT_EQ(new_goal.position().x(), teb.BackPose().position().x());
+  ASSERT_FLOAT_EQ(new_goal.position().y(), teb.BackPose().position().y());
+  ASSERT_FLOAT_EQ(new_goal.theta(), teb.BackPose().theta());
+  ASSERT_FLOAT_EQ(0.7, teb.BackTimeDiff());
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
* fix pruning of trajectory to also consider if the goal is approaching
  towards the robot. If driving around a U-shaped trajectory, the goal
  can first be in the local costmap but out of it afterwards.