### PR TITLE
Approach intermediate goal with full speed

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -147,9 +147,9 @@ grp_goal.add("free_goal_vel",   bool_t,   0,
 	"Allow the robot's velocity to be nonzero for planning purposes (the robot can arrive at the goal with max speed)", 
 	False)
 
-grp_goal.add("zero_velocity_at_goal_remaining_path_len", double_t, 0, 
-	"Restrict the robot's velocity to be zero if we are closer to the goal of the path from the global planner than this value", 
-	0., 0., 5.)
+grp_goal.add("addaptive_goal_vel", bool_t, 0,
+	"Allow the robot's velocity to be nonzero at intermediate goals (the robot will plan to stop at the goal of the global plan)",
+	False)
     
 # Obstacles
 grp_obstacles = gen.add_group("Obstacles", type="tab")

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -146,6 +146,10 @@ grp_goal.add("yaw_goal_tolerance", double_t, 0,
 grp_goal.add("free_goal_vel",   bool_t,   0, 
 	"Allow the robot's velocity to be nonzero for planning purposes (the robot can arrive at the goal with max speed)", 
 	False)
+
+grp_goal.add("zero_velocity_at_goal_remaining_path_len", double_t, 0, 
+	"Restrict the robot's velocity to be zero if we are closer to the goal of the path from the global planner than this value", 
+	0., 0., 5.)
     
 # Obstacles
 grp_obstacles = gen.add_group("Obstacles", type="tab")

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -110,7 +110,7 @@ public:
     double yaw_goal_tolerance; //!< Allowed final orientation error
     double xy_goal_tolerance; //!< Allowed final euclidean distance to the goal position
     bool free_goal_vel; //!< Allow the robot's velocity to be nonzero (usally max_vel) for planning purposes
-    double addaptive_goal_vel; //!< Allow the robot's velocity to be nonzero if we are not approaching to the global goal
+    bool addaptive_goal_vel; //!< Allow the robot's velocity to be nonzero if we are not approaching to the global goal
     bool complete_global_plan; // true prevents the robot from ending the path early when it cross the end goal
   } goal_tolerance; //!< Goal tolerance related parameters
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -110,7 +110,7 @@ public:
     double yaw_goal_tolerance; //!< Allowed final orientation error
     double xy_goal_tolerance; //!< Allowed final euclidean distance to the goal position
     bool free_goal_vel; //!< Allow the robot's velocity to be nonzero (usally max_vel) for planning purposes
-    double zero_velocity_at_goal_remaining_path_len; //!< Allow the robot's velocity to be nonzero if we are not closer than this value to the global goal
+    double addaptive_goal_vel; //!< Allow the robot's velocity to be nonzero if we are not approaching to the global goal
     bool complete_global_plan; // true prevents the robot from ending the path early when it cross the end goal
   } goal_tolerance; //!< Goal tolerance related parameters
 
@@ -271,7 +271,7 @@ public:
     goal_tolerance.xy_goal_tolerance = 0.2;
     goal_tolerance.yaw_goal_tolerance = 0.2;
     goal_tolerance.free_goal_vel = false;
-    goal_tolerance.zero_velocity_at_goal_remaining_path_len = 0.;
+    goal_tolerance.addaptive_goal_vel = false;
     goal_tolerance.complete_global_plan = true;
 
     // Obstacles

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -110,6 +110,7 @@ public:
     double yaw_goal_tolerance; //!< Allowed final orientation error
     double xy_goal_tolerance; //!< Allowed final euclidean distance to the goal position
     bool free_goal_vel; //!< Allow the robot's velocity to be nonzero (usally max_vel) for planning purposes
+    double zero_velocity_at_goal_remaining_path_len; //!< Allow the robot's velocity to be nonzero if we are not closer than this value to the global goal
     bool complete_global_plan; // true prevents the robot from ending the path early when it cross the end goal
   } goal_tolerance; //!< Goal tolerance related parameters
 
@@ -270,6 +271,7 @@ public:
     goal_tolerance.xy_goal_tolerance = 0.2;
     goal_tolerance.yaw_goal_tolerance = 0.2;
     goal_tolerance.free_goal_vel = false;
+    goal_tolerance.zero_velocity_at_goal_remaining_path_len = 0.;
     goal_tolerance.complete_global_plan = true;
 
     // Obstacles

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -86,6 +86,8 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("xy_goal_tolerance", goal_tolerance.xy_goal_tolerance, goal_tolerance.xy_goal_tolerance);
   nh.param("yaw_goal_tolerance", goal_tolerance.yaw_goal_tolerance, goal_tolerance.yaw_goal_tolerance);
   nh.param("free_goal_vel", goal_tolerance.free_goal_vel, goal_tolerance.free_goal_vel);
+  nh.param("zero_velocity_at_goal_remaining_path_len",
+           goal_tolerance.zero_velocity_at_goal_remaining_path_len, goal_tolerance.zero_velocity_at_goal_remaining_path_len);
   nh.param("complete_global_plan", goal_tolerance.complete_global_plan, goal_tolerance.complete_global_plan);
 
   // Obstacles
@@ -202,6 +204,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   goal_tolerance.xy_goal_tolerance = cfg.xy_goal_tolerance;
   goal_tolerance.yaw_goal_tolerance = cfg.yaw_goal_tolerance;
   goal_tolerance.free_goal_vel = cfg.free_goal_vel;
+  goal_tolerance.zero_velocity_at_goal_remaining_path_len = cfg.zero_velocity_at_goal_remaining_path_len;
   
   // Obstacles
   obstacles.min_obstacle_dist = cfg.min_obstacle_dist;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -86,8 +86,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("xy_goal_tolerance", goal_tolerance.xy_goal_tolerance, goal_tolerance.xy_goal_tolerance);
   nh.param("yaw_goal_tolerance", goal_tolerance.yaw_goal_tolerance, goal_tolerance.yaw_goal_tolerance);
   nh.param("free_goal_vel", goal_tolerance.free_goal_vel, goal_tolerance.free_goal_vel);
-  nh.param("zero_velocity_at_goal_remaining_path_len",
-           goal_tolerance.zero_velocity_at_goal_remaining_path_len, goal_tolerance.zero_velocity_at_goal_remaining_path_len);
+  nh.param("addaptive_goal_vel", goal_tolerance.addaptive_goal_vel, goal_tolerance.addaptive_goal_vel);
   nh.param("complete_global_plan", goal_tolerance.complete_global_plan, goal_tolerance.complete_global_plan);
 
   // Obstacles
@@ -204,7 +203,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   goal_tolerance.xy_goal_tolerance = cfg.xy_goal_tolerance;
   goal_tolerance.yaw_goal_tolerance = cfg.yaw_goal_tolerance;
   goal_tolerance.free_goal_vel = cfg.free_goal_vel;
-  goal_tolerance.zero_velocity_at_goal_remaining_path_len = cfg.zero_velocity_at_goal_remaining_path_len;
+  goal_tolerance.addaptive_goal_vel = cfg.addaptive_goal_vel;
   
   // Obstacles
   obstacles.min_obstacle_dist = cfg.min_obstacle_dist;

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -343,25 +343,10 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   // Do not allow config changes during the following optimization step
   boost::mutex::scoped_lock cfg_lock(cfg_.configMutex());
     
-  // determine if we plan on reaching a sub-goal as fast as possible
   bool free_goal_vel = cfg_.goal_tolerance.free_goal_vel;
-  if (free_goal_vel && cfg_.goal_tolerance.zero_velocity_at_goal_remaining_path_len > 0.)
-  { // arrive with zero velocity at the end of the global plan
-    bool close_to_global_goal = true;
-    double remaining_path_len = 0.;
-    for (int i = goal_idx; i < static_cast<int>(global_plan_.size()) - 1; ++i)
-    {
-      remaining_path_len += distance_points2d(global_plan_[i].pose.position, global_plan_[i+1].pose.position);
-      if (remaining_path_len > cfg_.goal_tolerance.zero_velocity_at_goal_remaining_path_len)
-      {
-        close_to_global_goal = false;
-        break;
-      }
-    }
-    if (close_to_global_goal)
-    { // we should start to compute a trajectory that decelerates towards the goal
-      free_goal_vel = false;
-    }
+  if (cfg_.goal_tolerance.addaptive_goal_vel)
+  { // arrive with zero velocity at the end of the global plan but fast on intermediate
+    free_goal_vel = goal_idx != static_cast<int>(global_plan_.size()) - 1;
   }
 
   // Now perform the actual planning


### PR DESCRIPTION
- added a parameter to determine if we are approaching an intermediate goal
- keep high velocity on an intermediate goal in the trajectory

free_goal_vel is set to false:
=> current behavior, TEB always plans to stop at the end of the TEB. As we plan to reach the goal of the global planner in our setting, this seems to be sub-optimal

If free_goal_vel is set to true and zero_velocity_at_goal_remaining_path_len is set to 0
=> the robot always tries to reach the end of the TEB as fast a possible. Also the target position of the global plan. We will overshoot the goal.

If free_goal_vel is set to true and zero_velocity_at_goal_remaining_path_len is set to, e.g., 0.5m
=> Only if the TEB ends close to the goal (closer than 0.5m) of the global plan, we plan to decelerate to a full stop of the robot.